### PR TITLE
change "valid" split names to "val"

### DIFF
--- a/src/eva/vision/data/datasets/patch_camelyon.py
+++ b/src/eva/vision/data/datasets/patch_camelyon.py
@@ -24,7 +24,7 @@ class PatchCamelyon(vision.VisionDataset[Tuple[np.ndarray, np.ndarray]]):
         ("camelyonpatch_level_2_split_train_x.h5", "01844da899645b4d6f84946d417ba453"),
         ("camelyonpatch_level_2_split_train_y.h5", "0781386bf6c2fb62d58ff18891466aca"),
     ]
-    valid_list = [
+    val_list = [
         ("camelyonpatch_level_2_split_valid_x.h5", "81cf9680f1724c40673f10dc88e909b1"),
         ("camelyonpatch_level_2_split_valid_y.h5", "94d8aacc249253159ce2a2e78a86e658"),
     ]
@@ -37,7 +37,7 @@ class PatchCamelyon(vision.VisionDataset[Tuple[np.ndarray, np.ndarray]]):
     def __init__(
         self,
         root: str,
-        split: Literal["train", "valid", "test"],
+        split: Literal["train", "val", "test"],
         download: bool = False,
         image_transforms: Callable | None = None,
         target_transforms: Callable | None = None,
@@ -158,7 +158,8 @@ class PatchCamelyon(vision.VisionDataset[Tuple[np.ndarray, np.ndarray]]):
         Returns:
             The relative file path for the H5 file based on the provided data type and split.
         """
-        filename = f"camelyonpatch_level_2_split_{self._split}_{datatype}.h5"
+        split_name = self._split if self._split != "val" else "valid"
+        filename = f"camelyonpatch_level_2_split_{split_name}_{datatype}.h5"
         return os.path.join(self._root, filename)
 
     @property
@@ -167,12 +168,12 @@ class PatchCamelyon(vision.VisionDataset[Tuple[np.ndarray, np.ndarray]]):
         match self._split:
             case "train":
                 return self.train_list
-            case "valid":
-                return self.valid_list
+            case "val":
+                return self.val_list
             case "test":
                 return self.test_list
             case _:
-                raise ValueError("Invalid data split. Use 'train', 'valid', or 'test'.")
+                raise ValueError("Invalid data split. Use 'train', 'val', or 'test'.")
 
     def _download_dataset(self) -> None:
         """Downloads the PatchCamelyon dataset."""

--- a/tests/eva/vision/data/datasets/test_bach.py
+++ b/tests/eva/vision/data/datasets/test_bach.py
@@ -12,7 +12,7 @@ from eva.vision.data import datasets
 
 @pytest.mark.parametrize(
     "split, expected_length",
-    [("train", 16), ("valid", 4), ("test", 4)],
+    [("train", 16), ("val", 4), ("test", 4)],
 )
 def test_length(bach_dataset: datasets.Bach, expected_length: int) -> None:
     """Tests the length of the dataset."""
@@ -21,7 +21,7 @@ def test_length(bach_dataset: datasets.Bach, expected_length: int) -> None:
 
 @pytest.mark.parametrize(
     "split",
-    ["train", "valid", "test"],
+    ["train", "val", "test"],
 )
 def test_sample(bach_dataset: datasets.Bach) -> None:
     """Tests the format of a dataset sample."""
@@ -38,7 +38,7 @@ def test_sample(bach_dataset: datasets.Bach) -> None:
 
 
 @pytest.fixture(scope="function")
-def bach_dataset(split: Literal["train", "valid", "test"], assets_path: str) -> datasets.Bach:
+def bach_dataset(split: Literal["train", "val", "test"], assets_path: str) -> datasets.Bach:
     """BACH dataset fixture."""
     with patch("eva.vision.data.datasets.Bach._verify_dataset") as _:
         ds = datasets.Bach(

--- a/tests/eva/vision/data/datasets/test_patch_camelyon.py
+++ b/tests/eva/vision/data/datasets/test_patch_camelyon.py
@@ -11,7 +11,7 @@ from eva.vision.data import datasets
 
 @pytest.mark.parametrize(
     "split, expected_length",
-    [("train", 4), ("valid", 2), ("test", 1)],
+    [("train", 4), ("val", 2), ("test", 1)],
 )
 def test_length(patch_camelyon_dataset: datasets.PatchCamelyon, expected_length: int) -> None:
     """Tests the length of the dataset."""
@@ -20,7 +20,7 @@ def test_length(patch_camelyon_dataset: datasets.PatchCamelyon, expected_length:
 
 @pytest.mark.parametrize(
     "split",
-    ["train", "valid", "test"],
+    ["train", "val", "test"],
 )
 def test_sample(patch_camelyon_dataset: datasets.PatchCamelyon) -> None:
     """Tests the format of a dataset sample."""
@@ -38,7 +38,7 @@ def test_sample(patch_camelyon_dataset: datasets.PatchCamelyon) -> None:
 
 @pytest.fixture(scope="function")
 def patch_camelyon_dataset(
-    split: Literal["train", "valid", "test"], assets_path: str
+    split: Literal["train", "val", "test"], assets_path: str
 ) -> datasets.PatchCamelyon:
     """PatchCamelyon dataset fixture."""
     return datasets.PatchCamelyon(


### PR DESCRIPTION
As discussed, changing `valid` to `val` in the patch_camelyon and bach dataset classes as "val" is the standard abbreviation for the validation split 