### PR TITLE
Update patch camelyon & bach training hyperparams

### DIFF
--- a/configs/vision/dino_vits16/bach.yaml
+++ b/configs/vision/dino_vits16/bach.yaml
@@ -67,8 +67,9 @@ data:
           image_transforms:
             class_path: eva.vision.data.transforms.common.ResizeAndCrop
             init_args:
-              mean: &NORMALIZE_MEAN [0.5, 0.5, 0.5]
-              std: &NORMALIZE_STD [0.5, 0.5, 0.5]
+              size: &RESIZE_DIM ${oc.env:RESIZE_DIM, 224}  
+              mean: &NORMALIZE_MEAN ${oc.env:NORMALIZE_MEAN, [0.485, 0.456, 0.406]} 
+              std: &NORMALIZE_STD ${oc.env:NORMALIZE_STD, [0.229, 0.224, 0.225]}
       val:
         class_path: eva.vision.datasets.BACH
         init_args:
@@ -78,6 +79,7 @@ data:
           image_transforms:
             class_path: eva.vision.data.transforms.common.ResizeAndCrop
             init_args:
+              size: *RESIZE_DIM
               mean: *NORMALIZE_MEAN
               std: *NORMALIZE_STD
       test:
@@ -89,6 +91,7 @@ data:
           image_transforms:
             class_path: eva.vision.data.transforms.common.ResizeAndCrop
             init_args:
+              size: *RESIZE_DIM
               mean: *NORMALIZE_MEAN
               std: *NORMALIZE_STD
     dataloaders:

--- a/configs/vision/dino_vits16/offline/bach.yaml
+++ b/configs/vision/dino_vits16/offline/bach.yaml
@@ -87,8 +87,9 @@ data:
             image_transforms:
               class_path: eva.vision.data.transforms.common.ResizeAndCrop
               init_args:
-                mean: &NORMALIZE_MEAN [0.5, 0.5, 0.5]
-                std: &NORMALIZE_STD [0.5, 0.5, 0.5]
+                size: &RESIZE_DIM ${oc.env:RESIZE_DIM, 224}  
+                mean: &NORMALIZE_MEAN ${oc.env:NORMALIZE_MEAN, [0.485, 0.456, 0.406]} 
+                std: &NORMALIZE_STD ${oc.env:NORMALIZE_STD, [0.229, 0.224, 0.225]}  
         - class_path: eva.vision.datasets.BACH
           init_args:
             root: ${oc.env:DATA_ROOT, ./data}/bach
@@ -101,11 +102,11 @@ data:
                 std: *NORMALIZE_STD
     dataloaders:
       train:
-        batch_size: &BATCH_SIZE 32
+        batch_size: &BATCH_SIZE 256
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
       test:
         batch_size: *BATCH_SIZE
       predict:
-        batch_size: &PREDICT_BATCH_SIZE 32
+        batch_size: &PREDICT_BATCH_SIZE 128

--- a/configs/vision/dino_vits16/offline/patch_camelyon.yaml
+++ b/configs/vision/dino_vits16/offline/patch_camelyon.yaml
@@ -95,8 +95,9 @@ data:
             image_transforms:
               class_path: eva.vision.data.transforms.common.ResizeAndCrop
               init_args:
-                mean: &NORMALIZE_MEAN [0.5, 0.5, 0.5]
-                std: &NORMALIZE_STD [0.5, 0.5, 0.5]
+                size: &RESIZE_DIM ${oc.env:RESIZE_DIM, 224}  
+                mean: &NORMALIZE_MEAN ${oc.env:NORMALIZE_MEAN, [0.485, 0.456, 0.406]} 
+                std: &NORMALIZE_STD ${oc.env:NORMALIZE_STD, [0.229, 0.224, 0.225]}
         - class_path: eva.vision.datasets.PatchCamelyon
           init_args:
             root: ${oc.env:DATA_ROOT, ./data}/patch_camelyon
@@ -119,11 +120,11 @@ data:
                 std: *NORMALIZE_STD
     dataloaders:
       train:
-        batch_size: &BATCH_SIZE 32
+        batch_size: &BATCH_SIZE 256
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
       test:
         batch_size: *BATCH_SIZE
       predict:
-        batch_size: &PREDICT_BATCH_SIZE 32
+        batch_size: &PREDICT_BATCH_SIZE 128

--- a/configs/vision/dino_vits16/patch_camelyon.yaml
+++ b/configs/vision/dino_vits16/patch_camelyon.yaml
@@ -67,8 +67,9 @@ data:
           image_transforms:
             class_path: eva.vision.data.transforms.common.ResizeAndCrop
             init_args:
-              mean: &NORMALIZE_MEAN [0.5, 0.5, 0.5]
-              std: &NORMALIZE_STD [0.5, 0.5, 0.5]
+              size: &RESIZE_DIM ${oc.env:RESIZE_DIM, 224}  
+              mean: &NORMALIZE_MEAN ${oc.env:NORMALIZE_MEAN, [0.485, 0.456, 0.406]} 
+              std: &NORMALIZE_STD ${oc.env:NORMALIZE_STD, [0.229, 0.224, 0.225]}
       val:
         class_path: eva.vision.datasets.PatchCamelyon
         init_args:
@@ -78,6 +79,7 @@ data:
           image_transforms:
             class_path: eva.vision.data.transforms.common.ResizeAndCrop
             init_args:
+              size: *RESIZE_DIM
               mean: *NORMALIZE_MEAN
               std: *NORMALIZE_STD
       test:
@@ -89,6 +91,7 @@ data:
           image_transforms:
             class_path: eva.vision.data.transforms.common.ResizeAndCrop
             init_args:
+              size: *RESIZE_DIM
               mean: *NORMALIZE_MEAN
               std: *NORMALIZE_STD
     dataloaders:

--- a/configs/vision/tests/offline/patch_camelyon.yaml
+++ b/configs/vision/tests/offline/patch_camelyon.yaml
@@ -90,8 +90,8 @@ data:
             image_transforms:
               class_path: eva.vision.data.transforms.common.ResizeAndCrop
               init_args:
-                mean: &NORMALIZE_MEAN [0.5, 0.5, 0.5]
-                std: &NORMALIZE_STD [0.5, 0.5, 0.5]
+                mean: &NORMALIZE_MEAN ${oc.env:NORMALIZE_MEAN, [0.485, 0.456, 0.406]} 
+                std: &NORMALIZE_STD ${oc.env:NORMALIZE_STD, [0.229, 0.224, 0.225]}
         - class_path: eva.vision.datasets.PatchCamelyon
           init_args:
             root: ${oc.env:TESTS_ROOT, tests/eva}/assets/vision/datasets/patch_camelyon

--- a/configs/vision/tests/patch_camelyon.yaml
+++ b/configs/vision/tests/patch_camelyon.yaml
@@ -47,8 +47,8 @@ data:
           image_transforms:
             class_path: eva.vision.data.transforms.common.ResizeAndCrop
             init_args:
-              mean: &NORMALIZE_MEAN [0.5, 0.5, 0.5]
-              std: &NORMALIZE_STD [0.5, 0.5, 0.5]
+              mean: &NORMALIZE_MEAN ${oc.env:NORMALIZE_MEAN, [0.485, 0.456, 0.406]} 
+              std: &NORMALIZE_STD ${oc.env:NORMALIZE_STD, [0.229, 0.224, 0.225]}
       val:
         class_path: eva.vision.datasets.PatchCamelyon
         init_args:

--- a/src/eva/vision/data/datasets/embeddings/patch.py
+++ b/src/eva/vision/data/datasets/embeddings/patch.py
@@ -5,7 +5,6 @@ from typing import Dict, Literal, Tuple
 
 import pandas as pd
 import torch
-import tqdm
 from typing_extensions import override
 
 from eva.vision.data.datasets.vision import VisionDataset
@@ -56,14 +55,12 @@ class PatchEmbeddingDataset(VisionDataset):
         self._path_column = self._column_mapping["path"]
         self._target_column = self._column_mapping["target"]
         self._split_column = self._column_mapping["split"]
-        self._embedding_column = "embedding_tensor"
 
     @override
     def __getitem__(self, index) -> Tuple[torch.Tensor, torch.Tensor]:
-        return (
-            self._data.at[index, self._embedding_column],
-            self._data.at[index, self._target_column],
-        )
+        embedding = self._load_embedding_file(index)
+        target = self._data.at[index, self._target_column]
+        return embedding, target
 
     @override
     def __len__(self) -> int:
@@ -76,13 +73,8 @@ class PatchEmbeddingDataset(VisionDataset):
     @override
     def setup(self):
         self._data = self._load_manifest()
-        self._data[self._embedding_column] = None
-
         self._data = self._data.loc[self._data[self._split_column] == self._split]
         self._data = self._data.reset_index(drop=True)
-
-        for index in tqdm.tqdm(self._data.index, desc="Loading embeddings"):
-            self._data.at[index, self._embedding_column] = self._load_embedding_file(index)
 
     def _load_embedding_file(self, index) -> torch.Tensor:
         path = self._get_embedding_path(index)

--- a/src/eva/vision/data/datasets/embeddings/slide.py
+++ b/src/eva/vision/data/datasets/embeddings/slide.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Literal, Tuple
 import pandas as pd
 import torch
 import torch.nn.functional as F
+import tqdm
 from typing_extensions import override
 
 from eva.vision.data.datasets.embeddings.patch import PatchEmbeddingDataset
@@ -65,6 +66,7 @@ class SlideEmbeddingDataset(PatchEmbeddingDataset):
         self._seed = seed
         self._pad_value = pad_value
         self._slide_id_column = self._column_mapping["slide_id"]
+        self._embedding_column = "embedding_tensor"
 
     @override
     def __getitem__(self, index) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
@@ -78,6 +80,11 @@ class SlideEmbeddingDataset(PatchEmbeddingDataset):
     @override
     def setup(self):
         super().setup()
+
+        self._data[self._embedding_column] = None
+        for index in tqdm.tqdm(self._data.index, desc="Loading embeddings"):
+            self._data.at[index, self._embedding_column] = self._load_embedding_file(index)
+
         self._data = self._sample_n_patches_per_slide(self._data)
 
     @override


### PR DESCRIPTION
This config yielded the following metrics for patch camelyon, using this checkpoint `experiments/pathology_fm/tcga/20240209/dino_vits16/version_0/checkpoints/teacher.backbone/last.pth`

<img width="928" alt="image" src="https://github.com/kaiko-ai/eva/assets/36882833/f541544e-de4a-4694-9a3d-cb65db7d0eea">

**How to reproduce?**
1. Download model checkpoint
2. Execute the following commands
```
export EMBEDDINGS_ROOT=/mnt/localdisk/data/embeddings/20240209/dino_vits16
export NORMALIZE_MEAN=[0.5,0.5,0.5]
export NORMALIZE_STD=[0.5,0.5,0.5]
export RESIZE_DIM=224  # optional because 224 is the default
eva predict_fit --config configs/vision/dino_vits16/offline/patch_camelyon.yaml --model.init_args.backbone.init_args.checkpoint_path /mnt/localdisk/data/models/20240209/dino_vits16/last.pth
```

(the generated embeddings will be stored in `EMBEDDINGS_ROOT/patch_camelyon`)