### PR TITLE
added pcam/resnet18 as a baseline config

### DIFF
--- a/configs/vision/resnet18/patch_camelyon.yaml
+++ b/configs/vision/resnet18/patch_camelyon.yaml
@@ -1,0 +1,101 @@
+---
+trainer:
+  class_path: eva.Trainer
+  init_args:
+    default_root_dir: &LIGHTNING_ROOT ${oc.env:LIGHTNING_ROOT, logs/resnet18/patch_camelyon}
+    max_epochs: &MAX_EPOCHS 2
+    callbacks:
+      - class_path: pytorch_lightning.callbacks.LearningRateMonitor
+        init_args:
+          logging_interval: epoch
+      - class_path: pytorch_lightning.callbacks.ModelCheckpoint
+        init_args:
+          filename: best
+          save_last: true
+          save_top_k: 1
+          monitor: &MONITOR_METRIC val/MulticlassAccuracy
+          mode: &MONITOR_METRIC_MODE max
+    logger:
+      - class_path: pytorch_lightning.loggers.TensorBoardLogger
+        init_args:
+          save_dir: *LIGHTNING_ROOT
+model:
+  class_path: eva.HeadModule
+  init_args:
+    backbone:
+      class_path: torch.nn.Identity
+    head:
+      class_path: eva.models.ModelFromFunction
+      init_args:
+        path: timm.create_model
+        arguments:
+          model_name: resnet18
+          num_classes: &NUM_CLASSES 2
+          drop_rate: 0.0
+          pretrained: true
+    criterion: torch.nn.CrossEntropyLoss
+    optimizer:
+      class_path: torch.optim.SGD
+      init_args:
+        lr: 0.0125
+        momentum: 0.9
+        weight_decay: 0.0
+    lr_scheduler:
+      class_path: torch.optim.lr_scheduler.CosineAnnealingLR
+      init_args:
+        T_max: *MAX_EPOCHS
+        eta_min: 0.0001
+    metrics:
+      common:
+        - class_path: eva.metrics.AverageLoss
+        - class_path: eva.metrics.MulticlassClassificationMetrics
+          init_args:
+            num_classes: *NUM_CLASSES
+data:
+  class_path: eva.DataModule
+  init_args:
+    datasets:
+      train:
+        class_path: eva.vision.datasets.PatchCamelyon
+        init_args:
+          root: ${oc.env:DATA_ROOT, ./data}/patch_camelyon
+          split: train
+          download: &DOWNLOAD_DATA ${oc.env:DOWNLOAD_DATA, true}
+          image_transforms:
+            class_path: eva.vision.data.transforms.common.ResizeAndCrop
+            init_args:
+              size: &RESIZE_DIM ${oc.env:RESIZE_DIM, 224}  
+              mean: &NORMALIZE_MEAN ${oc.env:NORMALIZE_MEAN, [0.485, 0.456, 0.406]} 
+              std: &NORMALIZE_STD ${oc.env:NORMALIZE_STD, [0.229, 0.224, 0.225]}
+      val:
+        class_path: eva.vision.datasets.PatchCamelyon
+        init_args:
+          root: ${oc.env:DATA_ROOT, ./data}/patch_camelyon
+          split: val
+          download: *DOWNLOAD_DATA
+          image_transforms:
+            class_path: eva.vision.data.transforms.common.ResizeAndCrop
+            init_args:
+              size: *RESIZE_DIM
+              mean: *NORMALIZE_MEAN
+              std: *NORMALIZE_STD
+      test:
+        class_path: eva.vision.datasets.PatchCamelyon
+        init_args:
+          root: ${oc.env:DATA_ROOT, ./data}/patch_camelyon
+          split: test
+          download: *DOWNLOAD_DATA
+          image_transforms:
+            class_path: eva.vision.data.transforms.common.ResizeAndCrop
+            init_args:
+              size: *RESIZE_DIM
+              mean: *NORMALIZE_MEAN
+              std: *NORMALIZE_STD
+    dataloaders:
+      train:
+        batch_size: &BATCH_SIZE 32
+        shuffle: true
+      val:
+        batch_size: *BATCH_SIZE
+      test:
+        batch_size: *BATCH_SIZE


### PR DESCRIPTION
Added a patch_camelyon/resnet18 online config as a baseline comparison. Obtained the results below when running with 2 epochs:
![Screenshot 2024-02-22 at 21 09 48](https://github.com/kaiko-ai/eva/assets/27897948/ded711bc-4d53-4678-b6a5-28577de409fe)
![Screenshot 2024-02-22 at 21 09 55](https://github.com/kaiko-ai/eva/assets/27897948/a8ba9948-4cd7-4fcb-8e56-c5adbd5c1f26)
