### PR TITLE
Parametrize backbone-model and input-dim

### DIFF
--- a/configs/vision/dino_vit/offline/bach.yaml
+++ b/configs/vision/dino_vit/offline/bach.yaml
@@ -33,7 +33,7 @@ trainer:
               path: torch.hub.load
               arguments:
                 repo_or_dir: facebookresearch/dino:main
-                model: ${oc.env:BACKBONE, dino_vits16}
+                model: ${oc.env:DINO_BACKBONE, dino_vits16}
                 pretrained: ${oc.env:PRETRAINED, true}
     logger:
       - class_path: pytorch_lightning.loggers.TensorBoardLogger

--- a/configs/vision/dino_vit/offline/crc.yaml
+++ b/configs/vision/dino_vit/offline/crc.yaml
@@ -33,7 +33,7 @@ trainer:
               path: torch.hub.load
               arguments:
                 repo_or_dir: facebookresearch/dino:main
-                model: ${oc.env:BACKBONE, dino_vits16}
+                model: ${oc.env:DINO_BACKBONE, dino_vits16}
                 pretrained: ${oc.env:PRETRAINED, true}
     logger:
       - class_path: pytorch_lightning.loggers.TensorBoardLogger

--- a/configs/vision/dino_vit/offline/crc_nonorm.yaml
+++ b/configs/vision/dino_vit/offline/crc_nonorm.yaml
@@ -33,7 +33,7 @@ trainer:
               path: torch.hub.load
               arguments:
                 repo_or_dir: facebookresearch/dino:main
-                model: ${oc.env:BACKBONE, dino_vits16}
+                model: ${oc.env:DINO_BACKBONE, dino_vits16}
                 pretrained: ${oc.env:PRETRAINED, true}
     logger:
       - class_path: pytorch_lightning.loggers.TensorBoardLogger

--- a/configs/vision/dino_vit/offline/patch_camelyon.yaml
+++ b/configs/vision/dino_vit/offline/patch_camelyon.yaml
@@ -34,7 +34,7 @@ trainer:
               path: torch.hub.load
               arguments:
                 repo_or_dir: facebookresearch/dino:main
-                model: ${oc.env:BACKBONE, dino_vits16}
+                model: ${oc.env:DINO_BACKBONE, dino_vits16}
                 pretrained: ${oc.env:PRETRAINED, true}
     logger:
       - class_path: pytorch_lightning.loggers.TensorBoardLogger
@@ -117,4 +117,4 @@ data:
       test:
         batch_size: *BATCH_SIZE
       predict:
-        batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 128}
+        batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}

--- a/configs/vision/dino_vit/online/bach.yaml
+++ b/configs/vision/dino_vit/online/bach.yaml
@@ -35,7 +35,7 @@ model:
         path: torch.hub.load
         arguments:
           repo_or_dir: facebookresearch/dino:main
-          model: ${oc.env:BACKBONE, dino_vits16}
+          model: ${oc.env:DINO_BACKBONE, dino_vits16}
           pretrained: ${oc.env:PRETRAINED, true}
         checkpoint_path: &CHECKPOINT_PATH ${oc.env:CHECKPOINT_PATH, null}
     head:

--- a/configs/vision/dino_vit/online/crc.yaml
+++ b/configs/vision/dino_vit/online/crc.yaml
@@ -35,7 +35,7 @@ model:
         path: torch.hub.load
         arguments:
           repo_or_dir: facebookresearch/dino:main
-          model: ${oc.env:BACKBONE, dino_vits16}
+          model: ${oc.env:DINO_BACKBONE, dino_vits16}
           pretrained: ${oc.env:PRETRAINED, true}
     head:
       class_path: torch.nn.Linear

--- a/configs/vision/dino_vit/online/crc_nonorm.yaml
+++ b/configs/vision/dino_vit/online/crc_nonorm.yaml
@@ -35,7 +35,7 @@ model:
         path: torch.hub.load
         arguments:
           repo_or_dir: facebookresearch/dino:main
-          model: ${oc.env:BACKBONE, dino_vits16}
+          model: ${oc.env:DINO_BACKBONE, dino_vits16}
           pretrained: ${oc.env:PRETRAINED, true}
     head:
       class_path: torch.nn.Linear

--- a/configs/vision/dino_vit/online/patch_camelyon.yaml
+++ b/configs/vision/dino_vit/online/patch_camelyon.yaml
@@ -35,7 +35,7 @@ model:
         path: torch.hub.load
         arguments:
           repo_or_dir: facebookresearch/dino:main
-          model: ${oc.env:BACKBONE, dino_vits16}
+          model: ${oc.env:DINO_BACKBONE, dino_vits16}
           pretrained: ${oc.env:PRETRAINED, true}
         checkpoint_path: &CHECKPOINT_PATH ${oc.env:CHECKPOINT_PATH, null}
     head:
@@ -89,7 +89,7 @@ data:
           split: test
     dataloaders:
       train:
-        batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 256}
+        batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE


### PR DESCRIPTION
Parametrizing the `trainer-callbacks-backbone-model` and `model-head-in_features` as follows:

`model: ${oc.env:BACKBONE, dino_vits16}`
`in_features: ${oc.env:IN_FEATURES, 384}`

Also updated the `patience` parameter to 10% of the max number of epochs ([Owkin](https://www.medrxiv.org/content/10.1101/2023.07.21.23292757v1.full.pdf) describes in section 4.2.1)