### PR TITLE
Change cli logo colour to blue

### DIFF
--- a/src/eva/cli/logo.py
+++ b/src/eva/cli/logo.py
@@ -11,7 +11,7 @@ _EVA_LOGO: str = r"""
 
 
 ANSI_LOGO_COLOR = "\33[0;34m"
-"""ANSI color reset code."""
+"""ANSI main logo color."""
 
 ANSI_COLOR_RESET = "\33[0m"
 """ANSI color reset code."""


### PR DESCRIPTION
Closes #270 

Options in order: blue, purple {currently}, cyan

<img width="837" alt="Screenshot 2024-03-17 at 3 44 30 PM" src="https://github.com/kaiko-ai/eva/assets/41287808/830ef25f-dbcd-4c4e-b101-8415ab4b2da0">
