### PR TITLE
Add `MultiEmbeddingsClassificationDataset`

### DIFF
--- a/docs/reference/core/data/datasets.md
+++ b/docs/reference/core/data/datasets.md
@@ -6,3 +6,4 @@ Reference information for the `Dataset` base class.
 
 ## Embeddings datasets
 ::: eva.core.data.datasets.EmbeddingsClassificationDataset
+::: eva.core.data.datasets.MultiEmbeddingsClassificationDataset

--- a/docs/reference/core/data/transforms.md
+++ b/docs/reference/core/data/transforms.md
@@ -1,0 +1,8 @@
+# Transforms
+
+::: eva.data.transforms.ArrayToTensor
+::: eva.data.transforms.ArrayToFloatTensor
+::: eva.data.transforms.Pad2DTensor
+::: eva.data.transforms.SampleFromAxis
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
         - reference/core/data/dataloaders.md
         - reference/core/data/datamodules.md
         - reference/core/data/datasets.md
+        - reference/core/data/transforms.md
       - Metrics: 
         - reference/core/metrics/index.md
         - reference/core/metrics/core.md

--- a/src/eva/core/data/datasets/__init__.py
+++ b/src/eva/core/data/datasets/__init__.py
@@ -1,7 +1,7 @@
 """Datasets API."""
 
 from eva.core.data.datasets.base import Dataset
-from eva.core.data.datasets.classification import EmbeddingsClassificationDataset
 from eva.core.data.datasets.dataset import TorchDataset
+from eva.core.data.datasets.embeddings.classification import EmbeddingsClassificationDataset
 
 __all__ = ["Dataset", "EmbeddingsClassificationDataset", "TorchDataset"]

--- a/src/eva/core/data/datasets/classification/__init__.py
+++ b/src/eva/core/data/datasets/classification/__init__.py
@@ -1,5 +1,0 @@
-"""Classification datasets API."""
-
-from eva.core.data.datasets.classification.embeddings import EmbeddingsClassificationDataset
-
-__all__ = ["EmbeddingsClassificationDataset"]

--- a/src/eva/core/data/datasets/embeddings/__init__.py
+++ b/src/eva/core/data/datasets/embeddings/__init__.py
@@ -1,15 +1,13 @@
 """Datasets API."""
 
-from eva.core.data.datasets.base import Dataset
-from eva.core.data.datasets.dataset import TorchDataset
-from eva.core.data.datasets.embeddings import (
+from eva.core.data.datasets.embeddings.base import EmbeddingsDataset
+from eva.core.data.datasets.embeddings.classification import (
     EmbeddingsClassificationDataset,
     MultiEmbeddingsClassificationDataset,
 )
 
 __all__ = [
-    "Dataset",
+    "EmbeddingsDataset",
     "EmbeddingsClassificationDataset",
     "MultiEmbeddingsClassificationDataset",
-    "TorchDataset",
 ]

--- a/src/eva/core/data/datasets/embeddings/base.py
+++ b/src/eva/core/data/datasets/embeddings/base.py
@@ -56,7 +56,7 @@ class EmbeddingsDataset(base.Dataset):
         self._root = root
         self._manifest_file = manifest_file
         self._split = split
-        self._column_mapping = column_mapping
+        self._column_mapping = default_column_mapping | column_mapping
         self._embeddings_transforms = embeddings_transforms
         self._target_transforms = target_transforms
 

--- a/src/eva/core/data/datasets/embeddings/base.py
+++ b/src/eva/core/data/datasets/embeddings/base.py
@@ -16,13 +16,13 @@ default_column_mapping: Dict[str, str] = {
     "path": "embeddings",
     "target": "target",
     "split": "split",
-    "slide_id": "slide_id",
+    "multi_id": "slide_id",
 }
 """The default column mapping of the variables to the manifest columns."""
 
 
 class EmbeddingsDataset(base.Dataset):
-    """Embeddings classification dataset."""
+    """Abstract base class for embedding datasets."""
 
     def __init__(
         self,
@@ -70,12 +70,8 @@ class EmbeddingsDataset(base.Dataset):
             index: The index of the data sample to load.
 
         Returns:
-            The sample embedding as an array.
+            The embedding sample as a tensor.
         """
-        filename = self.filename(index)
-        embeddings_path = os.path.join(self._root, filename)
-        tensor = torch.load(embeddings_path, map_location="cpu")
-        return tensor.squeeze(0)
 
     @abc.abstractmethod
     def _load_target(self, index: int) -> np.ndarray:
@@ -87,6 +83,10 @@ class EmbeddingsDataset(base.Dataset):
         Returns:
             The sample target as an array.
         """
+
+    @abc.abstractmethod
+    def __len__(self) -> int:
+        """Returns the total length of the data."""
 
     def filename(self, index: int) -> str:
         """Returns the filename of the `index`'th data sample.

--- a/src/eva/core/data/datasets/embeddings/base.py
+++ b/src/eva/core/data/datasets/embeddings/base.py
@@ -2,7 +2,7 @@
 
 import abc
 import os
-from typing import Callable, Dict, Tuple
+from typing import Callable, Dict, Literal, Tuple
 
 import numpy as np
 import pandas as pd
@@ -28,7 +28,7 @@ class EmbeddingsDataset(base.Dataset):
         self,
         root: str,
         manifest_file: str,
-        split: str | None = None,
+        split: Literal["train", "val", "test"] | None = None,
         column_mapping: Dict[str, str] = default_column_mapping,
         embeddings_transforms: Callable | None = None,
         target_transforms: Callable | None = None,

--- a/src/eva/core/data/datasets/embeddings/base.py
+++ b/src/eva/core/data/datasets/embeddings/base.py
@@ -1,5 +1,6 @@
-"""Embeddings classification dataset."""
+"""Base dataset class for Embeddings."""
 
+import abc
 import os
 from typing import Callable, Dict, Tuple
 
@@ -11,16 +12,17 @@ from typing_extensions import override
 from eva.core.data.datasets import base
 from eva.core.utils import io
 
+default_column_mapping: Dict[str, str] = {
+    "path": "embeddings",
+    "target": "target",
+    "split": "split",
+    "slide_id": "slide_id",
+}
+"""The default column mapping of the variables to the manifest columns."""
 
-class EmbeddingsClassificationDataset(base.Dataset):
+
+class EmbeddingsDataset(base.Dataset):
     """Embeddings classification dataset."""
-
-    default_column_mapping: Dict[str, str] = {
-        "data": "embeddings",
-        "target": "target",
-        "split": "split",
-    }
-    """The default column mapping of the variables to the manifest columns."""
 
     def __init__(
         self,
@@ -54,11 +56,37 @@ class EmbeddingsClassificationDataset(base.Dataset):
         self._root = root
         self._manifest_file = manifest_file
         self._split = split
-        self._column_mapping = self.default_column_mapping | column_mapping
+        self._column_mapping = column_mapping
         self._embeddings_transforms = embeddings_transforms
         self._target_transforms = target_transforms
 
         self._data: pd.DataFrame
+
+    @abc.abstractmethod
+    def _load_embeddings(self, index: int) -> torch.Tensor:
+        """Returns the `index`'th embedding sample.
+
+        Args:
+            index: The index of the data sample to load.
+
+        Returns:
+            The sample embedding as an array.
+        """
+        filename = self.filename(index)
+        embeddings_path = os.path.join(self._root, filename)
+        tensor = torch.load(embeddings_path, map_location="cpu")
+        return tensor.squeeze(0)
+
+    @abc.abstractmethod
+    def _load_target(self, index: int) -> np.ndarray:
+        """Returns the `index`'th target sample.
+
+        Args:
+            index: The index of the data sample to load.
+
+        Returns:
+            The sample target as an array.
+        """
 
     def filename(self, index: int) -> str:
         """Returns the filename of the `index`'th data sample.
@@ -71,7 +99,7 @@ class EmbeddingsClassificationDataset(base.Dataset):
         Returns:
             The filename of the `index`'th data sample.
         """
-        return self._data.at[index, self._column_mapping["data"]]
+        return self._data.at[index, self._column_mapping["path"]]
 
     @override
     def setup(self):
@@ -89,36 +117,6 @@ class EmbeddingsClassificationDataset(base.Dataset):
         embeddings = self._load_embeddings(index)
         target = self._load_target(index)
         return self._apply_transforms(embeddings, target)
-
-    def __len__(self) -> int:
-        """Returns the total length of the data."""
-        return len(self._data)
-
-    def _load_embeddings(self, index: int) -> torch.Tensor:
-        """Returns the `index`'th embedding sample.
-
-        Args:
-            index: The index of the data sample to load.
-
-        Returns:
-            The sample embedding as an array.
-        """
-        filename = self.filename(index)
-        embeddings_path = os.path.join(self._root, filename)
-        tensor = torch.load(embeddings_path, map_location="cpu")
-        return tensor.squeeze(0)
-
-    def _load_target(self, index: int) -> np.ndarray:
-        """Returns the `index`'th target sample.
-
-        Args:
-            index: The index of the data sample to load.
-
-        Returns:
-            The sample target as an array.
-        """
-        target = self._data.at[index, self._column_mapping["target"]]
-        return np.asarray(target, dtype=np.int64)
 
     def _load_manifest(self) -> pd.DataFrame:
         """Loads manifest file and filters the data based on the split column.

--- a/src/eva/core/data/datasets/embeddings/classification/__init__.py
+++ b/src/eva/core/data/datasets/embeddings/classification/__init__.py
@@ -1,0 +1,7 @@
+"""Classification datasets API."""
+
+from eva.core.data.datasets.embeddings.classification.embeddings import (
+    EmbeddingsClassificationDataset,
+)
+
+__all__ = ["EmbeddingsClassificationDataset"]

--- a/src/eva/core/data/datasets/embeddings/classification/__init__.py
+++ b/src/eva/core/data/datasets/embeddings/classification/__init__.py
@@ -1,7 +1,10 @@
-"""Classification datasets API."""
+"""Embedding cllassification datasets API."""
 
 from eva.core.data.datasets.embeddings.classification.embeddings import (
     EmbeddingsClassificationDataset,
 )
+from eva.core.data.datasets.embeddings.classification.multi_embeddings import (
+    MultiEmbeddingsClassificationDataset,
+)
 
-__all__ = ["EmbeddingsClassificationDataset"]
+__all__ = ["EmbeddingsClassificationDataset", "MultiEmbeddingsClassificationDataset"]

--- a/src/eva/core/data/datasets/embeddings/classification/embeddings.py
+++ b/src/eva/core/data/datasets/embeddings/classification/embeddings.py
@@ -51,14 +51,6 @@ class EmbeddingsClassificationDataset(base.EmbeddingsDataset):
 
     @override
     def _load_embeddings(self, index: int) -> torch.Tensor:
-        """Returns the `index`'th embedding sample.
-
-        Args:
-            index: The index of the data sample to load.
-
-        Returns:
-            The sample embedding as an array.
-        """
         filename = self.filename(index)
         embeddings_path = os.path.join(self._root, filename)
         tensor = torch.load(embeddings_path, map_location="cpu")
@@ -66,17 +58,9 @@ class EmbeddingsClassificationDataset(base.EmbeddingsDataset):
 
     @override
     def _load_target(self, index: int) -> np.ndarray:
-        """Returns the `index`'th target sample.
-
-        Args:
-            index: The index of the data sample to load.
-
-        Returns:
-            The sample target as an array.
-        """
         target = self._data.at[index, self._column_mapping["target"]]
         return np.asarray(target, dtype=np.int64)
 
+    @override
     def __len__(self) -> int:
-        """Returns the total length of the data."""
         return len(self._data)

--- a/src/eva/core/data/datasets/embeddings/classification/embeddings.py
+++ b/src/eva/core/data/datasets/embeddings/classification/embeddings.py
@@ -1,7 +1,7 @@
 """Embeddings classification dataset."""
 
 import os
-from typing import Callable, Dict
+from typing import Callable, Dict, Literal
 
 import numpy as np
 import torch
@@ -17,7 +17,7 @@ class EmbeddingsClassificationDataset(base.EmbeddingsDataset):
         self,
         root: str,
         manifest_file: str,
-        split: str | None = None,
+        split: Literal["train", "val", "test"] | None = None,
         column_mapping: Dict[str, str] = base.default_column_mapping,
         embeddings_transforms: Callable | None = None,
         target_transforms: Callable | None = None,

--- a/src/eva/core/data/datasets/embeddings/classification/embeddings.py
+++ b/src/eva/core/data/datasets/embeddings/classification/embeddings.py
@@ -1,0 +1,82 @@
+"""Embeddings classification dataset."""
+
+import os
+from typing import Callable, Dict
+
+import numpy as np
+import torch
+from typing_extensions import override
+
+from eva.core.data.datasets.embeddings import base
+
+
+class EmbeddingsClassificationDataset(base.EmbeddingsDataset):
+    """Embeddings classification dataset."""
+
+    def __init__(
+        self,
+        root: str,
+        manifest_file: str,
+        split: str | None = None,
+        column_mapping: Dict[str, str] = base.default_column_mapping,
+        embeddings_transforms: Callable | None = None,
+        target_transforms: Callable | None = None,
+    ) -> None:
+        """Initialize dataset.
+
+        Expects a manifest file listing the paths of .pt files that contain
+        tensor embeddings of shape [embedding_dim] or [1, embedding_dim].
+
+        Args:
+            root: Root directory of the dataset.
+            manifest_file: The path to the manifest file, which is relative to
+                the `root` argument.
+            split: The dataset split to use. The `split` column of the manifest
+                file will be splitted based on this value.
+            column_mapping: Defines the map between the variables and the manifest
+                columns. It will overwrite the `default_column_mapping` with
+                the provided values, so that `column_mapping` can contain only the
+                values which are altered or missing.
+            embeddings_transforms: A function/transform that transforms the embedding.
+            target_transforms: A function/transform that transforms the target.
+        """
+        super().__init__(
+            root=root,
+            manifest_file=manifest_file,
+            split=split,
+            column_mapping=column_mapping,
+            embeddings_transforms=embeddings_transforms,
+            target_transforms=target_transforms,
+        )
+
+    @override
+    def _load_embeddings(self, index: int) -> torch.Tensor:
+        """Returns the `index`'th embedding sample.
+
+        Args:
+            index: The index of the data sample to load.
+
+        Returns:
+            The sample embedding as an array.
+        """
+        filename = self.filename(index)
+        embeddings_path = os.path.join(self._root, filename)
+        tensor = torch.load(embeddings_path, map_location="cpu")
+        return tensor.squeeze(0)
+
+    @override
+    def _load_target(self, index: int) -> np.ndarray:
+        """Returns the `index`'th target sample.
+
+        Args:
+            index: The index of the data sample to load.
+
+        Returns:
+            The sample target as an array.
+        """
+        target = self._data.at[index, self._column_mapping["target"]]
+        return np.asarray(target, dtype=np.int64)
+
+    def __len__(self) -> int:
+        """Returns the total length of the data."""
+        return len(self._data)

--- a/src/eva/core/data/datasets/embeddings/classification/embeddings.py
+++ b/src/eva/core/data/datasets/embeddings/classification/embeddings.py
@@ -11,7 +11,7 @@ from eva.core.data.datasets.embeddings import base
 
 
 class EmbeddingsClassificationDataset(base.EmbeddingsDataset):
-    """Embeddings classification dataset."""
+    """Embeddings dataset class for classification tasks."""
 
     def __init__(
         self,

--- a/src/eva/core/data/datasets/embeddings/classification/multi_embeddings.py
+++ b/src/eva/core/data/datasets/embeddings/classification/multi_embeddings.py
@@ -29,7 +29,7 @@ class MultiEmbeddingsClassificationDataset(base.EmbeddingsDataset):
 
         Expects a manifest file listing the paths of `.pt` files containing tensor embeddings.
 
-        The manifest is required to have a `column_mapping["multi_id"]` column that contains the
+        The manifest must have a `column_mapping["multi_id"]` column that contains the
         unique identifier group of embeddings. For oncology datasets, this would be usually
         the slide id. Each row in the manifest file points to a .pt file that can contain
         one or multiple embeddings. There can also be multiple rows for the same `multi_id`,

--- a/src/eva/core/data/datasets/embeddings/classification/multi_embeddings.py
+++ b/src/eva/core/data/datasets/embeddings/classification/multi_embeddings.py
@@ -1,0 +1,108 @@
+"""Dataset class for slide embeddings (composed of multiple patch embeddings)."""
+
+import os
+from typing import Callable, Dict, List, Literal
+
+import numpy as np
+import torch
+from typing_extensions import override
+
+from eva.core.data.datasets.embeddings import base
+
+
+class MultiEmbeddingsClassificationDataset(base.EmbeddingsDataset):
+    """Embedding dataset."""
+
+    def __init__(
+        self,
+        root: str,
+        manifest_file: str,
+        split: Literal["train", "val", "test"],
+        column_mapping: Dict[str, str] = base.default_column_mapping,
+        embeddings_transforms: Callable | None = None,
+        target_transforms: Callable | None = None,
+    ):
+        """Initialize dataset.
+
+        Expects a manifest file listing the paths of `.pt` files. Each slide can have either
+        one or multiple `.pt` files, each containing a sequence of patch embeddings of shape
+        `[k, embedding_dim]`.
+
+        Args:
+            root: Root directory of the dataset.
+            manifest_file: The path to the manifest file, which is relative to
+                the `root` argument.
+            split: The dataset split to use. The `split` column of the manifest
+                file will be splitted based on this value.
+            column_mapping: Defines the map between the variables and the manifest
+                columns. It will overwrite the `default_column_mapping` with
+                the provided values, so that `column_mapping` can contain only the
+                values which are altered or missing.
+            embeddings_transforms: A function/transform that transforms the embedding.
+            target_transforms: A function/transform that transforms the target.
+        """
+        super().__init__(
+            manifest_file=manifest_file,
+            root=root,
+            split=split,
+            column_mapping=column_mapping,
+            embeddings_transforms=embeddings_transforms,
+            target_transforms=target_transforms,
+        )
+
+        self._slide_ids: List[int]
+
+    @override
+    def setup(self):
+        super().setup()
+        self._slide_ids = list(self._data[self._column_mapping["slide_id"]].unique())
+
+    @override
+    def _load_embeddings(self, index: int) -> torch.Tensor:
+        """Returns the `index`'th embedding sample.
+
+        Args:
+            index: The index of the data sample to load.
+
+        Returns:
+            The sample embedding as an array.
+        """
+        # Get all embeddings for the slide
+        slide_id = self._slide_ids[index]
+        embedding_paths = self._data.loc[
+            self._data[self._column_mapping["slide_id"]] == slide_id, self._column_mapping["path"]
+        ].to_list()
+        embedding_paths = [os.path.join(self._root, path) for path in embedding_paths]
+
+        # Load embeddings and stack
+        embeddings = [torch.load(path, map_location="cpu") for path in embedding_paths]
+        embeddings = torch.cat(embeddings, dim=0)
+
+        if not embeddings.ndim == 2:
+            raise ValueError(f"Expected 2D tensor, got {embeddings.ndim} for slide {slide_id}.")
+
+        return embeddings
+
+    @override
+    def _load_target(self, index: int) -> np.ndarray:
+        """Returns the `index`'th target sample.
+
+        Args:
+            index: The index of the data sample to load.
+
+        Returns:
+            The sample target as an array.
+        """
+        slide_id = self._slide_ids[index]
+        slide_targets = self._data.loc[
+            self._data[self._column_mapping["slide_id"]] == slide_id, self._column_mapping["target"]
+        ]
+
+        if not slide_targets.nunique() == 1:
+            raise ValueError(f"Multiple targets found for slide {slide_id}.")
+
+        return slide_targets.iloc[0]
+
+    def __len__(self) -> int:
+        """Returns the total length of the data."""
+        return len(self._data)

--- a/src/eva/core/data/datasets/embeddings/classification/multi_embeddings.py
+++ b/src/eva/core/data/datasets/embeddings/classification/multi_embeddings.py
@@ -101,7 +101,7 @@ class MultiEmbeddingsClassificationDataset(base.EmbeddingsDataset):
         if not slide_targets.nunique() == 1:
             raise ValueError(f"Multiple targets found for slide {slide_id}.")
 
-        return slide_targets.iloc[0]
+        return np.asarray(slide_targets.iloc[0], dtype=np.int64)
 
     def __len__(self) -> int:
         """Returns the total length of the data."""

--- a/src/eva/core/data/datasets/embeddings/classification/multi_embeddings.py
+++ b/src/eva/core/data/datasets/embeddings/classification/multi_embeddings.py
@@ -13,7 +13,7 @@ from eva.core.data.datasets.embeddings import base
 class MultiEmbeddingsClassificationDataset(base.EmbeddingsDataset):
     """Dataset class for where a sample corresponds to multiple embeddings.
 
-    Example Usecase: Slide level dataset where each slide has multiple patch embeddings.
+    Example use case: Slide level dataset where each slide has multiple patch embeddings.
     """
 
     def __init__(

--- a/src/eva/core/data/transforms/__init__.py
+++ b/src/eva/core/data/transforms/__init__.py
@@ -1,5 +1,7 @@
 """Core data transforms."""
 
 from eva.core.data.transforms.dtype import ArrayToFloatTensor, ArrayToTensor
+from eva.core.data.transforms.padding import Pad2DTensor
+from eva.core.data.transforms.sampling import SampleFromAxis
 
-__all__ = ["ArrayToFloatTensor", "ArrayToTensor"]
+__all__ = ["ArrayToFloatTensor", "ArrayToTensor", "Pad2DTensor", "SampleFromAxis"]

--- a/src/eva/core/data/transforms/padding/__init__.py
+++ b/src/eva/core/data/transforms/padding/__init__.py
@@ -1,0 +1,5 @@
+"""Padding related transformations."""
+
+from eva.core.data.transforms.padding.pad_2d_tensor import Pad2DTensor
+
+__all__ = ["Pad2DTensor"]

--- a/src/eva/core/data/transforms/padding/pad_2d_tensor.py
+++ b/src/eva/core/data/transforms/padding/pad_2d_tensor.py
@@ -1,0 +1,38 @@
+"""Padding transformation for 2D tensors."""
+
+import torch
+import torch.nn.functional
+
+
+class Pad2DTensor:
+    """Pads a 2D tensor to a fixed dimension accross the first dimension."""
+
+    def __init__(self, pad_size: int, pad_value: int | float = float("-inf")):
+        """Initialize the transformation.
+
+        Args:
+            pad_size: The size to pad the tensor to. If the tensor is larger than this size,
+                no padding will be applied.
+            pad_value: The value to use for padding.
+        """
+        self._pad_size = pad_size
+        self._pad_value = pad_value
+
+    def __call__(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Call method for the transformation.
+
+        Args:
+            tensor: The input tensor of shape [n, embedding_dim].
+
+        Returns:
+            A tensor of shape [max(n, pad_dim), embedding_dim].
+        """
+        n_pad_values = self._pad_size - tensor.size(0)
+        if n_pad_values > 0:
+            tensor = torch.nn.functional.pad(
+                tensor,
+                pad=(0, 0, 0, n_pad_values),
+                mode="constant",
+                value=self._pad_value,
+            )
+        return tensor

--- a/src/eva/core/data/transforms/sampling/__init__.py
+++ b/src/eva/core/data/transforms/sampling/__init__.py
@@ -1,0 +1,5 @@
+"""Sampling related transformations."""
+
+from eva.core.data.transforms.sampling.sample_from_axis import SampleFromAxis
+
+__all__ = ["SampleFromAxis"]

--- a/src/eva/core/data/transforms/sampling/sample_from_axis.py
+++ b/src/eva/core/data/transforms/sampling/sample_from_axis.py
@@ -6,7 +6,7 @@ import torch
 class SampleFromAxis:
     """Samples n_samples entries from a tensor along a given axis."""
 
-    def __init__(self, n_samples: int, seed: int, axis: int = 0):
+    def __init__(self, n_samples: int, seed: int = 42, axis: int = 0):
         """Initialize the transformation.
 
         Args:

--- a/src/eva/core/data/transforms/sampling/sample_from_axis.py
+++ b/src/eva/core/data/transforms/sampling/sample_from_axis.py
@@ -1,0 +1,40 @@
+"""Sampling transformations."""
+
+import torch
+
+
+class SampleFromAxis:
+    """Samples n_samples entries from a tensor along a given axis."""
+
+    def __init__(self, n_samples: int, seed: int, axis: int = 0):
+        """Initialize the transformation.
+
+        Args:
+            n_samples: The number of samples to draw.
+            seed: The seed to use for sampling.
+            axis: The axis along which to sample.
+        """
+        self._seed = seed
+        self._n_samples = n_samples
+        self._axis = axis
+        self._generator = self._get_generator()
+
+    def _get_generator(self):
+        """Return a torch random generator with fixed seed."""
+        generator = torch.Generator()
+        generator.manual_seed(self._seed)
+        return generator
+
+    def __call__(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Call method for the transformation.
+
+        Args:
+            tensor: The input tensor of shape [n, embedding_dim].
+
+        Returns:
+            A tensor of shape [n_samples, embedding_dim].
+        """
+        indices = torch.randperm(tensor.size(self._axis), generator=self._generator)[
+            : self._n_samples
+        ]
+        return tensor[indices]

--- a/src/eva/core/data/transforms/sampling/sample_from_axis.py
+++ b/src/eva/core/data/transforms/sampling/sample_from_axis.py
@@ -37,4 +37,4 @@ class SampleFromAxis:
         indices = torch.randperm(tensor.size(self._axis), generator=self._generator)[
             : self._n_samples
         ]
-        return tensor[indices]
+        return tensor.index_select(self._axis, indices)

--- a/tests/eva/core/data/datasets/classification/__init__.py
+++ b/tests/eva/core/data/datasets/classification/__init__.py
@@ -1,1 +1,0 @@
-"""Tests for core classification datasets."""

--- a/tests/eva/core/data/datasets/classification/test_embedding_datasets.py
+++ b/tests/eva/core/data/datasets/classification/test_embedding_datasets.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 import torch
 
-from eva.core.data.datasets import classification
+from eva.core.data.datasets.embeddings import classification
 
 
 @pytest.mark.parametrize(

--- a/tests/eva/core/data/datasets/embeddings/__init__.py
+++ b/tests/eva/core/data/datasets/embeddings/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for embeddings datasets."""

--- a/tests/eva/core/data/datasets/embeddings/classification/__init__.py
+++ b/tests/eva/core/data/datasets/embeddings/classification/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for classification embeddings datasets."""

--- a/tests/eva/core/data/datasets/embeddings/classification/test_embeddings.py
+++ b/tests/eva/core/data/datasets/embeddings/classification/test_embeddings.py
@@ -1,7 +1,7 @@
 """Tests for the embeddings datasets."""
 
 import os
-from typing import Tuple
+from typing import Literal
 
 import numpy as np
 import pytest
@@ -10,37 +10,37 @@ import torch
 from eva.core.data.datasets.embeddings import classification
 
 
-@pytest.mark.parametrize(
-    "split, embeddings_shape",
-    [("train", (8,)), ("val", (8,))],
-)
-def test_patch_embedding_dataset(
-    patch_embeddings_dataset: classification.EmbeddingsClassificationDataset,
-    embeddings_shape: Tuple[int, ...],
-):
-    """Test that the EmbeddingsClassificationDataset level dataset."""
+@pytest.mark.parametrize("split", ["train", "val"])
+def test_embedding_dataset(embeddings_dataset: classification.EmbeddingsClassificationDataset):
+    """Tests that the dataset returns data in the expected format."""
     # assert data sample is a tuple
-    sample = patch_embeddings_dataset[0]
+    sample = embeddings_dataset[0]
     assert isinstance(sample, tuple)
     assert len(sample) == 2
     # assert the format of the `image` and `target`
     embeddings, target = sample
     assert isinstance(embeddings, torch.Tensor)
-    assert embeddings.shape == embeddings_shape
+    assert embeddings.shape == (8,)
     assert isinstance(target, np.ndarray)
     assert target in [0, 1]
 
 
 @pytest.fixture(scope="function")
-def patch_embeddings_dataset(
-    split: str, assets_path: str
+def embeddings_dataset(
+    split: Literal["train", "val", "test"], root_dir: str
 ) -> classification.EmbeddingsClassificationDataset:
     """EmbeddingsClassificationDataset dataset fixture."""
     dataset = classification.EmbeddingsClassificationDataset(
-        root=os.path.join(assets_path, "core", "datasets", "embeddings"),
+        root=root_dir,
         manifest_file="manifest.csv",
         split=split,
     )
     dataset.prepare_data()
     dataset.setup()
     return dataset
+
+
+@pytest.fixture(scope="function")
+def root_dir(assets_path: str):
+    """Returns the root directory of the test embeddings dataset."""
+    return os.path.join(assets_path, "core", "datasets", "embeddings")

--- a/tests/eva/core/data/datasets/embeddings/classification/test_multi_embeddings.py
+++ b/tests/eva/core/data/datasets/embeddings/classification/test_multi_embeddings.py
@@ -1,0 +1,106 @@
+"""Tests for the embeddings datasets."""
+
+import os
+from typing import Literal, Tuple
+
+import numpy as np
+import pytest
+import torch
+import torch.nn
+
+from eva.core.data import transforms
+from eva.core.data.datasets.embeddings import classification
+
+
+@pytest.mark.parametrize(
+    "split, expected_shape",
+    [("train", (9, 8)), ("val", (5, 8))],
+)
+def test_embedding_dataset(
+    embeddings_dataset: classification.MultiEmbeddingsClassificationDataset,
+    expected_shape: Tuple[int, ...],
+):
+    """Tests that the dataset returns data in the expected format."""
+    # assert data sample is a tuple
+    sample = embeddings_dataset[0]
+    assert isinstance(sample, tuple)
+    assert len(sample) == 2
+    # assert the format of the `image` and `target`
+    embeddings, target = sample
+    assert isinstance(embeddings, torch.Tensor)
+    assert embeddings.shape == expected_shape
+    assert isinstance(target, np.ndarray)
+    assert target in [0, 1]
+
+
+@pytest.mark.parametrize(
+    "split, n_samples, pad_size, pad_value",
+    [("train", 3, 50, float("-inf")), ("val", 4, 7, -1)],
+)
+def test_embedding_dataset_with_transform(
+    embeddings_dataset_with_transform: classification.MultiEmbeddingsClassificationDataset,
+    n_samples: int,
+    pad_size: int,
+    pad_value: int | float,
+):
+    """Tests that the dataset returns data in the expected format with transforms."""
+    # assert data sample is a tuple
+    sample = embeddings_dataset_with_transform[0]
+    assert isinstance(sample, tuple)
+    assert len(sample) == 2
+    # assert the format of the `image` and `target`
+    embeddings, target = sample
+    assert isinstance(embeddings, torch.Tensor)
+    assert embeddings.shape == (pad_size, 8)
+    assert isinstance(target, np.ndarray)
+    assert target in [0, 1]
+    # assert the number of padded entries
+    mask = embeddings == pad_value
+    mask = mask.all(dim=-1, keepdim=True)
+    assert mask.sum() == pad_size - n_samples
+
+
+@pytest.fixture(scope="function")
+def embeddings_dataset(
+    split: Literal["train", "val", "test"], root_dir: str
+) -> classification.MultiEmbeddingsClassificationDataset:
+    """EmbeddingsClassificationDataset dataset fixture."""
+    dataset = classification.MultiEmbeddingsClassificationDataset(
+        root=root_dir,
+        manifest_file="manifest.csv",
+        split=split,
+    )
+    dataset.prepare_data()
+    dataset.setup()
+    return dataset
+
+
+@pytest.fixture(scope="function")
+def embeddings_dataset_with_transform(
+    split: Literal["train", "val", "test"],
+    root_dir: str,
+    n_samples: int,
+    pad_size: int,
+    pad_value: int | float,
+) -> classification.MultiEmbeddingsClassificationDataset:
+    """EmbeddingsClassificationDataset dataset fixture."""
+
+    def _embeddings_transforms(tensor: torch.Tensor) -> torch.Tensor:
+        tensor = transforms.SampleFromAxis(n_samples)(tensor)
+        return transforms.Pad2DTensor(pad_size, pad_value)(tensor)
+
+    dataset = classification.MultiEmbeddingsClassificationDataset(
+        root=root_dir,
+        manifest_file="manifest.csv",
+        split=split,
+        embeddings_transforms=_embeddings_transforms,
+    )
+    dataset.prepare_data()
+    dataset.setup()
+    return dataset
+
+
+@pytest.fixture(scope="function")
+def root_dir(assets_path: str):
+    """Returns the root directory of the test embeddings dataset."""
+    return os.path.join(assets_path, "core", "datasets", "multi-embeddings")

--- a/tests/eva/core/data/transforms/__init__.py
+++ b/tests/eva/core/data/transforms/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for core transforms."""

--- a/tests/eva/core/data/transforms/padding/__init__.py
+++ b/tests/eva/core/data/transforms/padding/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for padding transforms."""

--- a/tests/eva/core/data/transforms/padding/test_pad_2d_tensor.py
+++ b/tests/eva/core/data/transforms/padding/test_pad_2d_tensor.py
@@ -1,0 +1,49 @@
+"""Tests for Pad2DTensor transformation."""
+
+from typing import Tuple
+
+import torch
+
+from eva.core.data.transforms import Pad2DTensor
+
+
+def test_no_padding_needed():
+    """Test case where tensor larger than pad size and no padding is needed."""
+    pad_size = 5
+    embedding_dim = 10
+    tensor = create_tensor((6, embedding_dim))
+    transformation = Pad2DTensor(pad_size=pad_size)
+    result_tensor = transformation(tensor)
+    assert result_tensor.shape == tensor.shape, "No padding should be applied"
+
+
+def test_padding_needed():
+    """Test case where tensor smaller than pad size and padding should be applied."""
+    pad_size = 5
+    embedding_dim = 10
+    tensor = create_tensor((3, embedding_dim))  # tensor smaller than pad size
+    transformation = Pad2DTensor(pad_size=pad_size)
+    result_tensor = transformation(tensor)
+    assert result_tensor.shape == (
+        pad_size,
+        embedding_dim,
+    ), "Padding should be applied to match the pad_size"
+
+
+def test_padding_value():
+    """Test if padded entries have the correct value."""
+    pad_size = 5
+    embedding_dim = 10
+    tensor = create_tensor((3, embedding_dim))
+    pad_value = 0
+    transformation = Pad2DTensor(pad_size=pad_size, pad_value=pad_value)
+    result_tensor = transformation(tensor)
+    # Check if padding values are as expected
+    assert (
+        result_tensor[3:] == pad_value
+    ).all(), "Padded values should match the specified pad_value"
+
+
+def create_tensor(shape: Tuple[int, ...], value: float = 1.0):
+    """Helper function to create a tensor."""
+    return torch.full(shape, fill_value=value, dtype=torch.float32)

--- a/tests/eva/core/data/transforms/sampling/__init__.py
+++ b/tests/eva/core/data/transforms/sampling/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for sampling transforms."""

--- a/tests/eva/core/data/transforms/sampling/test_sample_from_axis.py
+++ b/tests/eva/core/data/transforms/sampling/test_sample_from_axis.py
@@ -1,0 +1,71 @@
+"""Tests for SampleFromAxis transformation."""
+
+from typing import Tuple
+
+import torch
+
+from eva.core.data.transforms import SampleFromAxis
+
+
+def test_correct_number_of_samples():
+    """Ensure the sampled tensor has the correct number of samples."""
+    tensor = create_tensor((10, 5))  # Create a 10x5 tensor
+    transformation = SampleFromAxis(n_samples=3)
+    sampled_tensor = transformation(tensor)
+    assert sampled_tensor.shape == (3, 5), "Output tensor should have 3 samples along the 0th axis"
+
+
+def test_consistency_with_seed():
+    """Check if the same seed results in the same sampled output."""
+    tensor = create_tensor((10, 5))
+    transformation1 = SampleFromAxis(n_samples=3, seed=42)
+    transformation2 = SampleFromAxis(n_samples=3, seed=42)
+    assert torch.equal(
+        transformation1(tensor), transformation2(tensor)
+    ), "Sampling with the same seed should produce identical results"
+
+
+def test_axis_sampling():
+    """Verify that sampling occurs along the correct axis."""
+    tensor = create_tensor((5, 10))  # Create a 5x10 tensor
+    transformation = SampleFromAxis(n_samples=3, axis=1)
+    sampled_tensor = transformation(tensor)
+    assert sampled_tensor.shape == (5, 3), "Output tensor should have 3 samples along the 1st axis"
+
+
+def test_n_samples_greater_than_dimension():
+    """Ensure correct behavior when n_samples exceeds the axis dimension."""
+    tensor = create_tensor((5, 10))
+    transformation = SampleFromAxis(
+        n_samples=10, axis=0
+    )  # Request more samples than available in axis 0
+    sampled_tensor = transformation(tensor)
+    assert sampled_tensor.shape == (
+        5,
+        10,
+    ), "Output tensor should remain unchanged when n_samples exceeds axis dimension"
+
+
+def test_zero_samples():
+    """Test the behavior when n_samples is set to zero."""
+    tensor = create_tensor((10, 5))
+    transformation = SampleFromAxis(n_samples=0)
+    sampled_tensor = transformation(tensor)
+    assert (
+        sampled_tensor.numel() == 0
+    ), "Output tensor should have zero elements when n_samples is zero"
+
+
+def test_single_dimension_tensor():
+    """Check sampling from a tensor with only one dimension."""
+    tensor = create_tensor((10,))  # Create a tensor with only one dimension
+    transformation = SampleFromAxis(n_samples=3)
+    sampled_tensor = transformation(tensor)
+    assert sampled_tensor.shape == (
+        3,
+    ), "Output tensor should correctly sample from a single-dimension tensor"
+
+
+def create_tensor(shape: Tuple[int, ...], value: float = 1.0):
+    """Helper function to create a tensor."""
+    return torch.full(shape, fill_value=value, dtype=torch.float32)


### PR DESCRIPTION
Closes #350 

- Refactors embedding dataset classes
- Add a new `MultiEmbeddingsClassificationDataset` to support slide level tasks
  - The class is written in a way that is agnostic to WSIs
- The transformations `SampleFromAxis` and `Pad2DTensor` are included in this PR, because they are needed for common MIL setups in slide level tasks (e.g. our abmil implementation expects padded tensors of shape `(batch_size, n_instances, input_size)`)