### PR TITLE
Disable Loggers that don't support saving to remote storage at runtime

### DIFF
--- a/docs/reference/core/data/datasets.md
+++ b/docs/reference/core/data/datasets.md
@@ -2,7 +2,7 @@
 
 Reference information for the `Dataset` base class.
 
-::: eva.data.Dataset
+::: eva.core.data.Dataset
 
 ## Embeddings datasets
 ::: eva.core.data.datasets.EmbeddingsClassificationDataset

--- a/docs/reference/core/loggers/loggers.md
+++ b/docs/reference/core/loggers/loggers.md
@@ -1,0 +1,3 @@
+# Loggers
+
+::: eva.core.loggers.DummyLogger

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -106,6 +106,7 @@ nav:
       - Trainers:
         - Trainer: reference/core/trainers/trainer.md
         - Functional: reference/core/trainers/functional.md
+      - Loggers: reference/core/loggers/loggers.md
       - Utils:
         - Multiprocessing: reference/core/utils/multiprocessing.md
         - Workers: reference/core/utils/workers.md

--- a/src/eva/core/loggers/__init__.py
+++ b/src/eva/core/loggers/__init__.py
@@ -1,0 +1,5 @@
+"""Loggers API."""
+
+from eva.core.loggers.dummy import DummyLogger
+
+__all__ = ["DummyLogger"]

--- a/src/eva/core/loggers/dummy.py
+++ b/src/eva/core/loggers/dummy.py
@@ -1,3 +1,5 @@
+"""Dummy logger class."""
+
 import lightning.pytorch.loggers.logger
 
 
@@ -16,17 +18,20 @@ class DummyLogger(lightning.pytorch.loggers.logger.DummyLogger):
     """
 
     def __init__(self, save_dir: str) -> None:
-        """Initializes the placeholder logger.
+        """Initializes the logger.
 
         Args:
-            save_dir: The directory to save the logs.
+            save_dir: The save directory (this logger does not save anything,
+                but callbacks might use this path to save their outputs).
         """
         super().__init__()
         self._save_dir = save_dir
 
     @property
     def save_dir(self) -> str:
+        """Returns the save directory."""
         return self._save_dir
 
     def __deepcopy__(self, memo=None):
+        """Override of the deepcopy method."""
         return self

--- a/src/eva/core/loggers/dummy.py
+++ b/src/eva/core/loggers/dummy.py
@@ -1,0 +1,32 @@
+import lightning.pytorch.loggers.logger
+
+
+class DummyLogger(lightning.pytorch.loggers.logger.DummyLogger):
+    """Dummy logger class.
+
+    This logger is currently used as a placeholder when saving results
+    to remote storage, as common lightning loggers do not work
+    with azure blob storage:
+    https://github.com/Lightning-AI/pytorch-lightning/issues/18861
+    https://github.com/Lightning-AI/pytorch-lightning/issues/19736
+
+    Simply disabling the loggers when pointing to remote storage doesn't work
+    because callbacks such as LearningRateMonitor or ModelCheckpoint require a
+    logger to be present.
+    """
+
+    def __init__(self, save_dir: str) -> None:
+        """Initializes the placeholder logger.
+
+        Args:
+            save_dir: The directory to save the logs.
+        """
+        super().__init__()
+        self._save_dir = save_dir
+
+    @property
+    def save_dir(self) -> str:
+        return self._save_dir
+
+    def __deepcopy__(self, memo=None):
+        return self

--- a/src/eva/core/loggers/dummy.py
+++ b/src/eva/core/loggers/dummy.py
@@ -9,8 +9,9 @@ class DummyLogger(lightning.pytorch.loggers.logger.DummyLogger):
     This logger is currently used as a placeholder when saving results
     to remote storage, as common lightning loggers do not work
     with azure blob storage:
-    https://github.com/Lightning-AI/pytorch-lightning/issues/18861
-    https://github.com/Lightning-AI/pytorch-lightning/issues/19736
+
+    <https://github.com/Lightning-AI/pytorch-lightning/issues/18861>
+    <https://github.com/Lightning-AI/pytorch-lightning/issues/19736>
 
     Simply disabling the loggers when pointing to remote storage doesn't work
     because callbacks such as LearningRateMonitor or ModelCheckpoint require a

--- a/src/eva/core/trainers/_logging.py
+++ b/src/eva/core/trainers/_logging.py
@@ -87,7 +87,7 @@ class PlaceholderLogger(DummyLogger):
     """Placeholder logger class.
 
     This placeholder is currently used when saving results to remote storage, as
-    common lightning loggers do not work with azure remote storage:
+    common lightning loggers do not work with azure blob storage:
     https://github.com/Lightning-AI/pytorch-lightning/issues/18861
     https://github.com/Lightning-AI/pytorch-lightning/issues/19736
 

--- a/src/eva/core/trainers/_logging.py
+++ b/src/eva/core/trainers/_logging.py
@@ -86,7 +86,7 @@ def _generate_hash_from_config(path: str, max_hash_len: int = 8) -> str:
 class PlaceholderLogger(DummyLogger):
     """Placeholder logger class.
 
-    This is placeholder currently used when saving results to remote storage, as
+    This placeholder is currently used when saving results to remote storage, as
     common lightning loggers do not work with azure remote storage:
     https://github.com/Lightning-AI/pytorch-lightning/issues/18861
     https://github.com/Lightning-AI/pytorch-lightning/issues/19736

--- a/src/eva/core/trainers/_logging.py
+++ b/src/eva/core/trainers/_logging.py
@@ -4,7 +4,6 @@ import hashlib
 import sys
 from datetime import datetime
 
-from lightning.pytorch.loggers.logger import DummyLogger
 from lightning_fabric.utilities import cloud_io
 from loguru import logger
 
@@ -81,33 +80,3 @@ def _generate_hash_from_config(path: str, max_hash_len: int = 8) -> str:
         config_sha256 = hashlib.sha256(config)
         hash_id = config_sha256.hexdigest()
     return hash_id[:max_hash_len]
-
-
-class PlaceholderLogger(DummyLogger):
-    """Placeholder logger class.
-
-    This placeholder is currently used when saving results to remote storage, as
-    common lightning loggers do not work with azure blob storage:
-    https://github.com/Lightning-AI/pytorch-lightning/issues/18861
-    https://github.com/Lightning-AI/pytorch-lightning/issues/19736
-
-    Simply disabling the loggers when pointing to remote storage doesn't work
-    because callbacks such as LearningRateMonitor or ModelCheckpoint require a
-    logger to be present.
-    """
-
-    def __init__(self, save_dir: str) -> None:
-        """Initializes the placeholder logger.
-
-        Args:
-            save_dir: The directory to save the logs.
-        """
-        super().__init__()
-        self._save_dir = save_dir
-
-    @property
-    def save_dir(self) -> str:
-        return self._save_dir
-
-    def __deepcopy__(self, memo=None):
-        return self

--- a/src/eva/core/trainers/trainer.py
+++ b/src/eva/core/trainers/trainer.py
@@ -10,6 +10,7 @@ from lightning.pytorch.utilities import argparse
 from lightning_fabric.utilities import cloud_io
 from typing_extensions import override
 
+from eva.core import loggers as eva_loggers
 from eva.core.data import datamodules
 from eva.core.models import modules
 from eva.core.trainers import _logging, functional
@@ -83,7 +84,7 @@ class Trainer(pl_trainer.Trainer):
                         logger._version = subdirectory
                 enabled_loggers.append(logger)
 
-        self._loggers = enabled_loggers or [_logging.PlaceholderLogger(self._log_dir)]
+        self._loggers = enabled_loggers or [eva_loggers.DummyLogger(self._log_dir)]
 
     def run_evaluation_session(
         self,

--- a/src/eva/core/trainers/trainer.py
+++ b/src/eva/core/trainers/trainer.py
@@ -81,13 +81,9 @@ class Trainer(pl_trainer.Trainer):
                         logger._root_dir = self.default_root_dir
                         logger._name = self._session_id
                         logger._version = subdirectory
-                elif logger is not None:
-                    enabled_loggers.append(logger)
+                enabled_loggers.append(logger)
 
-        if len(enabled_loggers) > 0:
-            self._loggers = enabled_loggers
-        else:
-            self._loggers = [_logging.PlaceholderLogger(self._log_dir)]
+        self._loggers = enabled_loggers or [_logging.PlaceholderLogger(self._log_dir)]
 
     def run_evaluation_session(
         self,

--- a/src/eva/core/trainers/trainer.py
+++ b/src/eva/core/trainers/trainer.py
@@ -74,8 +74,7 @@ class Trainer(pl_trainer.Trainer):
                 if isinstance(logger, (pl_loggers.CSVLogger, pl_loggers.TensorBoardLogger)):
                     if not cloud_io._is_local_file_protocol(self.default_root_dir):
                         loguru.logger.warning(
-                            f"Skipping {type(logger).__name__} Logger as "
-                            "remote storage is not supported."
+                            f"Skipped {type(logger).__name__} as remote storage is not supported."
                         )
                         continue
                     else:


### PR DESCRIPTION
Closes #338 

If `OUTPUT_ROOT` is set to a remote path and the config file lists loggers that don't support remote storage, the loggers will be disabled at runtime and a warning will be displayed:

<img width="605" alt="image" src="https://github.com/kaiko-ai/eva/assets/36882833/2470ef2c-a47b-4a30-be93-129ced944800">

With that change, we can now store the evaluation results directly to remote storage. 