### PR TITLE
run baseline panda workflows

### DIFF
--- a/configs/vision/dino_vit/offline/panda.yaml
+++ b/configs/vision/dino_vit/offline/panda.yaml
@@ -1,0 +1,126 @@
+---
+trainer:
+  class_path: eva.Trainer
+  init_args:
+    n_runs: &N_RUNS ${oc.env:N_RUNS, 1}
+    default_root_dir: &OUTPUT_ROOT ${oc.env:OUTPUT_ROOT, logs/${oc.env:DINO_BACKBONE, dino_vits16}/offline/panda}
+    max_steps: &MAX_STEPS ${oc.env:MAX_STEPS, 12500}
+    callbacks:
+      - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+        init_args:
+          logging_interval: epoch
+      - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+        init_args:
+          filename: best
+          save_last: true
+          save_top_k: 1
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/MulticlassAccuracy}
+          mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
+      - class_path: lightning.pytorch.callbacks.EarlyStopping
+        init_args:
+          min_delta: 0
+          patience: 200
+          monitor: *MONITOR_METRIC
+          mode: *MONITOR_METRIC_MODE
+      - class_path: eva.callbacks.EmbeddingsWriter
+        init_args:
+          output_dir: &DATASET_EMBEDDINGS_ROOT ${oc.env:EMBEDDINGS_ROOT, ./data/embeddings}/${oc.env:DINO_BACKBONE, dino_vits16}/panda
+          dataloader_idx_map:
+            0: train
+            1: val
+            2: test
+          backbone:
+            class_path: eva.models.ModelFromFunction
+            init_args:
+              path: torch.hub.load
+              arguments:
+                repo_or_dir: ${oc.env:REPO_OR_DIR, facebookresearch/dino:main}
+                model: ${oc.env:DINO_BACKBONE, dino_vits16}
+                pretrained: ${oc.env:PRETRAINED, true}
+                force_reload: ${oc.env:FORCE_RELOAD, false}
+              checkpoint_path: ${oc.env:CHECKPOINT_PATH, null}
+    logger:
+      - class_path: lightning.pytorch.loggers.TensorBoardLogger
+        init_args:
+          save_dir: *OUTPUT_ROOT
+          name: ""
+model:
+  class_path: eva.HeadModule
+  init_args:
+    head:
+      class_path: eva.vision.models.networks.ABMIL
+      init_args:
+        input_size: ${oc.env:IN_FEATURES, 384}
+        output_size: &NUM_CLASSES 6
+    criterion: torch.nn.CrossEntropyLoss
+    optimizer:
+      class_path: torch.optim.SGD
+      init_args:
+        lr: &LR_VALUE ${oc.env:LR_VALUE, 0.000625}
+        momentum: 0.9
+        weight_decay: 0.0
+    lr_scheduler:
+      class_path: torch.optim.lr_scheduler.CosineAnnealingLR
+      init_args:
+        T_max: *MAX_STEPS
+        eta_min: 0.0
+    metrics:
+      common:
+        - class_path: eva.metrics.AverageLoss
+        - class_path: eva.metrics.MulticlassClassificationMetrics
+          init_args:
+            num_classes: *NUM_CLASSES
+data:
+  class_path: eva.DataModule
+  init_args:
+    datasets:
+      train:
+        class_path: eva.datasets.MultiEmbeddingsClassificationDataset
+        init_args: &DATASET_ARGS
+          root: *DATASET_EMBEDDINGS_ROOT
+          manifest_file: manifest.csv
+          split: train
+      val:
+        class_path: eva.datasets.MultiEmbeddingsClassificationDataset
+        init_args:
+          <<: *DATASET_ARGS
+          split: val
+      test:
+        class_path: eva.datasets.MultiEmbeddingsClassificationDataset
+        init_args:
+          <<: *DATASET_ARGS
+          split: test
+      predict:
+        - class_path: eva.vision.datasets.MultiWsiClassificationDataset
+          init_args: &PREDICT_DATASET_ARGS
+            root: ${oc.env:DATA_ROOT, ./slide_data}/panda
+            manifest_file: manifest_train.csv
+            n_samples: 100
+            width: 224
+            height: 224
+            target_mpp: 0.5
+            transforms:
+              class_path: eva.vision.data.transforms.common.ResizeAndCrop
+              init_args:
+                size: ${oc.env:RESIZE_DIM, 224} 
+                mean: ${oc.env:NORMALIZE_MEAN, [0.485, 0.456, 0.406]} 
+                std: ${oc.env:NORMALIZE_STD, [0.229, 0.224, 0.225]}
+        - class_path: eva.vision.datasets.MultiWsiClassificationDataset
+          init_args:
+            <<: *PREDICT_DATASET_ARGS
+            manifest_file: manifest_val.csv
+        - class_path: eva.vision.datasets.MultiWsiClassificationDataset
+          init_args:
+            <<: *PREDICT_DATASET_ARGS
+            manifest_file: manifest_test.csv
+    dataloaders:
+      train:
+        batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 128}
+        shuffle: true
+      val:
+        batch_size: *BATCH_SIZE
+      predict:
+        batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: 12 #multiprocessing.cpu_count
+        prefetch_factor: 2
+

--- a/src/eva/core/callbacks/writers/typings.py
+++ b/src/eva/core/callbacks/writers/typings.py
@@ -21,3 +21,6 @@ class QUEUE_ITEM(NamedTuple):
 
     split: str | None
     """The dataset split the item belongs to (e.g. train, val, test)."""
+
+    slide_id: str | None = None
+    """Name of the original input file that was used to generate the embedding."""

--- a/src/eva/core/data/datasets/embeddings/classification/multi_embeddings.py
+++ b/src/eva/core/data/datasets/embeddings/classification/multi_embeddings.py
@@ -77,6 +77,7 @@ class MultiEmbeddingsClassificationDataset(base.EmbeddingsDataset):
 
         # Load embeddings and stack them accross the first dimension
         embeddings = [torch.load(path, map_location="cpu") for path in embedding_paths]
+        embeddings = [embedding.unsqueeze(0) if embedding.ndim==1 else embedding for embedding in embeddings]
         embeddings = torch.cat(embeddings, dim=0)
 
         if not embeddings.ndim == 2:
@@ -103,4 +104,4 @@ class MultiEmbeddingsClassificationDataset(base.EmbeddingsDataset):
 
     @override
     def __len__(self) -> int:
-        return len(self._data)
+        return len(self._multi_ids)

--- a/src/eva/vision/data/datasets/classification/wsi.py
+++ b/src/eva/vision/data/datasets/classification/wsi.py
@@ -1,5 +1,4 @@
 import bisect
-import random
 from typing import Any, Dict
 
 import numpy as np
@@ -16,10 +15,15 @@ class MultiWsiClassificationDataset(MultiWsiDataset):
 
         return DATA_SAMPLE(data, target, metadata)
 
+    # TODO: create panda-specific dataset class for functions below
     def _load_target(self, index: int) -> np.ndarray:
         dataset_idx = bisect.bisect_right(self.cumulative_sizes, index)
         return self._manifest.at[dataset_idx, self._column_mapping["target"]]
 
     def _load_metadata(self, index: int) -> Dict[str, Any]:
-        # TODO: Implement metadata loading
-        return {"slide_id": random.randint(0, 100)}
+        return {"slide_id": self.filename(index).split(".")[0]}
+    
+    def filename(self, index: int) -> str:
+        dataset_idx = bisect.bisect_right(self.cumulative_sizes, index)
+        full_path = self._manifest.at[dataset_idx, self._column_mapping["path"]]
+        return full_path.split("/")[-1]


### PR DESCRIPTION
Adjustments and config to run baseline panda experiment with `eva predict_fit --config configs/vision/dino_vit/offline/panda.yaml`.

To do so, first download panda data and create manifest files with:

```
import fsspec
import os
import pandas as pd

N_SLIDES = 1_000
TRAIN_SPLIT = 0.6
VAL_SPLIT = 0.2

metadata_url = "az://ml-datasets-public@kaiko.blob.core.windows.net/cpath/wsi/panda/prostate-cancer-grade-assessment/train.csv"
images_url = "az://ml-datasets-public@kaiko.blob.core.windows.net/cpath/wsi/panda/prostate-cancer-grade-assessment/train_images"
local_path = "<local/path/to/repo>/slide_data/panda/"

with fsspec.open(metadata_url) as f1:
    metadata_df = pd.read_csv(f1)

metadata_sample_df = metadata_df.sample(N_SLIDES, random_state=42)
all_slides = [x + '.tiff' for x in metadata_sample_df["image_id"].values]

# save manifest files:
metadata_sample_df = metadata_sample_df[["image_id", "isup_grade"]]
metadata_sample_df.columns = ["path", "target"]
metadata_sample_df["path"] = metadata_sample_df["path"].apply(lambda x: local_path + x + ".tiff")

n_train = int(N_SLIDES*TRAIN_SPLIT)
n_val = int(N_SLIDES*VAL_SPLIT)

metadata_sample_df.iloc[:n_train,:].to_csv(os.path.join(local_path, "manifest_train.csv"), index=False)
metadata_sample_df.iloc[n_train:n_train+n_val,:].to_csv(os.path.join(local_path, "manifest_val.csv"), index=False)
metadata_sample_df.iloc[n_train:n_train+n_val:,:].to_csv(os.path.join(local_path, "manifest_test.csv"), index=False)

# download slides:
for slide in slides:
    slide_path = os.path.join(images_url, slide)
    with fsspec.open(slide_path) as f1:
        data = f1.read()
        with fsspec.open(os.path.join('slide_data/panda', slide), 'wb') as f2:
            f2.write(data)
```