### PR TITLE
fix panda pipeline

### DIFF
--- a/configs/vision/dino_vit/offline/panda.yaml
+++ b/configs/vision/dino_vit/offline/panda.yaml
@@ -96,14 +96,16 @@ data:
           init_args: &PREDICT_DATASET_ARGS
             root: ${oc.env:DATA_ROOT, ./slide_data}/panda
             manifest_file: manifest_train.csv
-            n_samples: 100
+            sampler: 
+              class_path: eva.vision.data.wsi.patching.samplers.RandomSampler
+              init_args:
+                n_samples: 100
             width: 224
             height: 224
-            target_mpp: 0.5
+            target_mpp: 0.503
             transforms:
               class_path: eva.vision.data.transforms.common.ResizeAndCrop
               init_args:
-                size: ${oc.env:RESIZE_DIM, 224} 
                 mean: ${oc.env:NORMALIZE_MEAN, [0.485, 0.456, 0.406]} 
                 std: ${oc.env:NORMALIZE_STD, [0.229, 0.224, 0.225]}
         - class_path: eva.vision.datasets.MultiWsiClassificationDataset
@@ -124,4 +126,3 @@ data:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
         num_workers: 12 #multiprocessing.cpu_count
         prefetch_factor: 2
-

--- a/src/eva/vision/data/datasets/wsi.py
+++ b/src/eva/vision/data/datasets/wsi.py
@@ -76,7 +76,7 @@ class WsiDataset(vision.VisionDataset):
         x, y = self._coords.x_y[index]
         width, height, level_idx = self._coords.width, self._coords.height, self._coords.level_idx
         patch = self._wsi.read_region((x, y), (width, height), level_idx)
-        patch = self._apply_transforms(torch.from_numpy(patch))
+        patch = self._apply_transforms(patch)
         return patch
 
     def _apply_transforms(self, tensor: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
adjust panda-config and fix transforms to allow running panda example with `eva predict_fit --config configs/vision/dino_vit/offline/panda.yaml` (as described in https://github.com/kaiko-ai/eva/pull/373)