### PR TITLE
Updated `EmbeddingsWriter` to support multi-embedding file outputs

### DIFF
--- a/configs/vision/dino_vit/offline/panda.yaml
+++ b/configs/vision/dino_vit/offline/panda.yaml
@@ -24,12 +24,12 @@ trainer:
           mode: *MONITOR_METRIC_MODE
       - class_path: eva.callbacks.EmbeddingsWriter
         init_args:
-          group_key: slide_id
           output_dir: &DATASET_EMBEDDINGS_ROOT ${oc.env:EMBEDDINGS_ROOT, ./data/embeddings}/${oc.env:DINO_BACKBONE, dino_vits16}/panda
           dataloader_idx_map:
             0: train
             1: val
             2: test
+          metadata_keys: ["slide_id"]
           backbone:
             class_path: eva.models.ModelFromFunction
             init_args:

--- a/src/eva/core/callbacks/writers/embeddings.py
+++ b/src/eva/core/callbacks/writers/embeddings.py
@@ -3,7 +3,7 @@
 import csv
 import io
 import os
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, List, Sequence
 
 import lightning.pytorch as pl
 import torch
@@ -12,7 +12,7 @@ from loguru import logger
 from torch import multiprocessing, nn
 from typing_extensions import override
 
-from eva.core.callbacks.writers.typings import QUEUE_ITEM
+from eva.core.callbacks.writers.typings import ITEM_DICT_ENTRY, QUEUE_ITEM
 from eva.core.models.modules.typings import DATA_SAMPLE
 from eva.core.utils import multiprocessing as eva_multiprocessing
 
@@ -27,6 +27,7 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter):
         dataloader_idx_map: Dict[int, str] | None = None,
         group_key: str | None = None,
         overwrite: bool = True,
+        save_every_n: int = 1000,
     ) -> None:
         """Initializes a new EmbeddingsWriter instance.
 
@@ -43,6 +44,8 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter):
                 embedding files will be saved in subdirectories named after the group_key.
                 If specified, the key must be present in the metadata of the input batch.
             overwrite: Whether to overwrite the output directory. Defaults to True.
+            save_every_n: Interval for number of iterations to save the embeddings to disk.
+                During this interval, the embeddings are accumulated in memory.
         """
         super().__init__(write_interval="batch")
 
@@ -51,6 +54,7 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter):
         self._dataloader_idx_map = dataloader_idx_map or {}
         self._group_key = group_key
         self._overwrite = overwrite
+        self._save_every_n = save_every_n
 
         self._write_queue: multiprocessing.Queue
         self._write_process: eva_multiprocessing.Process
@@ -85,8 +89,6 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter):
             input_name, save_name = self._construct_save_name(
                 dataset.filename(global_idx), metadata, local_idx
             )
-            # TODO: group multiple embeddings into one file and remove line below
-            save_name = save_name.split(".")[0] + f"_{global_idx}.pt"
             embeddings_buffer, target_buffer = io.BytesIO(), io.BytesIO()
             torch.save(embeddings[local_idx].clone(), embeddings_buffer)
             torch.save(targets[local_idx], target_buffer)  # type: ignore
@@ -111,7 +113,8 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter):
     def _initialize_write_process(self) -> None:
         self._write_queue = multiprocessing.Queue()
         self._write_process = eva_multiprocessing.Process(
-            target=_process_write_queue, args=(self._write_queue, self._output_dir, self._overwrite)
+            target=_process_write_queue,
+            args=(self._write_queue, self._output_dir, self._save_every_n, self._overwrite),
         )
 
     def _get_embeddings(self, prediction: torch.Tensor) -> torch.Tensor:
@@ -131,26 +134,68 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter):
 
 
 def _process_write_queue(
-    write_queue: multiprocessing.Queue, output_dir: str, overwrite: bool = False
+    write_queue: multiprocessing.Queue, output_dir: str, save_every_n: int, overwrite: bool = False
 ) -> None:
     manifest_file, manifest_writer = _init_manifest(output_dir, overwrite)
+
+    save_name_to_items: Dict[str, ITEM_DICT_ENTRY] = {}
+
+    counter = 0
     while True:
         item = write_queue.get()
         if item is None:
             break
 
-        prediction_buffer, target_buffer, input_name, save_name, split, slide_id = QUEUE_ITEM(*item)
-        _save_prediction(prediction_buffer, save_name, output_dir)
-        _update_manifest(target_buffer, input_name, save_name, split, slide_id, manifest_writer)
+        item = QUEUE_ITEM(*item)
+
+        if item.save_name in save_name_to_items:
+            save_name_to_items[item.save_name].items.append(item)
+        else:
+            save_name_to_items[item.save_name] = ITEM_DICT_ENTRY(items=[item], save_count=0)
+
+        if counter > 0 and counter % save_every_n == 0:
+            save_name_to_items = _save_items(save_name_to_items, output_dir, manifest_writer)
+
+        counter += 1
+
+    if len(save_name_to_items) > 0:
+        _save_items(save_name_to_items, output_dir, manifest_writer)
 
     manifest_file.close()
 
 
-def _save_prediction(prediction_buffer: io.BytesIO, save_name: str, output_dir: str) -> None:
-    save_path = os.path.join(output_dir, save_name)
-    prediction = torch.load(io.BytesIO(prediction_buffer.getbuffer()), map_location="cpu")
+def _save_items(
+    save_name_to_items: Dict[str, ITEM_DICT_ENTRY], output_dir: str, manifest_writer: Any
+) -> Dict[str, ITEM_DICT_ENTRY]:
+    for save_name, entry in save_name_to_items.items():
+        save_path = os.path.join(output_dir, save_name)
+        is_first_save = entry.save_count == 0
+        if is_first_save:
+            _, target, input_name, _, split, slide_id = QUEUE_ITEM(*entry.items[0])
+            _update_manifest(target, input_name, save_name, split, slide_id, manifest_writer)
+        else:
+            pass
+        prediction_buffers = [item.prediction_buffer for item in entry.items]
+        _save_predictions(prediction_buffers, save_path, is_first_save)
+        save_name_to_items[save_name].save_count += 1
+
+    return save_name_to_items
+
+
+def _save_predictions(
+    prediction_buffers: List[io.BytesIO], save_path: str, is_first_save: bool
+) -> None:
+    predictions = [
+        torch.load(io.BytesIO(buffer.getbuffer()), map_location="cpu")
+        for buffer in prediction_buffers
+    ]
+    predictions = torch.stack(predictions, dim=0)
+
+    if not is_first_save:
+        predictions = torch.cat([torch.load(save_path), predictions], dim=0)
+
     os.makedirs(os.path.dirname(save_path), exist_ok=True)
-    torch.save(prediction, save_path)
+    torch.save(predictions, save_path)
 
 
 def _init_manifest(output_dir: str, overwrite: bool = False) -> tuple[io.TextIOWrapper, Any]:

--- a/src/eva/core/callbacks/writers/embeddings.py
+++ b/src/eva/core/callbacks/writers/embeddings.py
@@ -125,10 +125,15 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter):
         with torch.no_grad():
             return self._backbone(prediction)
 
-    def _get_item_metadata(self, metadata: Dict[str, List[Any]], local_idx: int) -> Dict[str, Any]:
+    def _get_item_metadata(
+        self, metadata: Dict[str, Any] | None, local_idx: int
+    ) -> Dict[str, Any] | None:
         """Returns the metadata for the item at the given local index."""
-        if not metadata and self._metadata_keys:
-            raise ValueError("Metadata keys are provided but the batch metadata is empty.")
+        if not metadata:
+            if self._metadata_keys:
+                raise ValueError("Metadata keys are provided but the batch metadata is empty.")
+            else:
+                return None
 
         item_metadata = {}
         for key in self._metadata_keys:

--- a/src/eva/core/callbacks/writers/typings.py
+++ b/src/eva/core/callbacks/writers/typings.py
@@ -1,26 +1,38 @@
 """Typing definitions for the writer callback functions."""
 
+import dataclasses
 import io
-from typing import NamedTuple
+from typing import List, NamedTuple
 
 
 class QUEUE_ITEM(NamedTuple):
     """The default input batch data scheme."""
 
     prediction_buffer: io.BytesIO
-    """IO buffer containing the prediction tensor"""
+    """IO buffer containing the prediction tensor."""
 
     target_buffer: io.BytesIO
-    """IO buffer containing the target tensor"""
+    """IO buffer containing the target tensor."""
 
     input_name: str
     """Name of the original input file that was used to generate the embedding."""
 
     save_name: str
-    """Name to store the generated embedding"""
+    """Name to store the generated embedding."""
 
     split: str | None
     """The dataset split the item belongs to (e.g. train, val, test)."""
 
     slide_id: str | None = None
     """Unique slide identifier."""
+
+
+@dataclasses.dataclass
+class ITEM_DICT_ENTRY:
+    """Typing for holding queue items and number of save operations."""
+
+    items: List[QUEUE_ITEM]
+    """List of queue items."""
+
+    save_count: int
+    """Number of prior item batch saves to same file."""

--- a/src/eva/core/callbacks/writers/typings.py
+++ b/src/eva/core/callbacks/writers/typings.py
@@ -2,7 +2,7 @@
 
 import dataclasses
 import io
-from typing import List, NamedTuple
+from typing import Any, Dict, List, NamedTuple
 
 
 class QUEUE_ITEM(NamedTuple):
@@ -23,8 +23,8 @@ class QUEUE_ITEM(NamedTuple):
     split: str | None
     """The dataset split the item belongs to (e.g. train, val, test)."""
 
-    slide_id: str | None = None
-    """Unique slide identifier."""
+    metadata: Dict[str, Any] | None = None
+    """Dictionary holding additional metadata."""
 
 
 @dataclasses.dataclass

--- a/tests/eva/core/callbacks/writers/test_embeddings.py
+++ b/tests/eva/core/callbacks/writers/test_embeddings.py
@@ -4,11 +4,13 @@ import os
 import random
 import tempfile
 from pathlib import Path
-from typing import List, Literal
+from typing import List, Literal, Set
 
 import lightning.pytorch as pl
 import pandas as pd
 import pytest
+import torch
+from lightning.pytorch import callbacks
 from lightning.pytorch.demos import boring_classes
 from torch import nn
 from typing_extensions import override
@@ -21,57 +23,126 @@ SAMPLE_SHAPE = 32
 
 
 @pytest.mark.parametrize(
-    "batch_size, n_samples",
+    "batch_size, n_samples, metadata_keys, filenames",
     [
-        (5, 7),
-        (8, 16),
+        (5, 7, None, None),
+        (5, 7, ["slide_id"], None),
+        (8, 16, None, None),
+        (8, 32, ["slide_id"], ["slide_1", "slide_2"]),
     ],
 )
 def test_embeddings_writer(datamodule: datamodules.DataModule, model: modules.HeadModule) -> None:
-    """Tests the embeddings writer callback."""
+    """Tests the embeddings writer callback.
+
+    This test executes a lightning trainer predict operation and checks if the expected
+    embedding tensors & manifest files are correctly written to disk.
+    """
     with tempfile.TemporaryDirectory() as output_dir:
-        trainer = pl.Trainer(
-            logger=False,
-            callbacks=writers.EmbeddingsWriter(
-                output_dir=output_dir,
-                dataloader_idx_map={0: "train", 1: "val", 2: "test"},
-                backbone=nn.Flatten(),
-            ),
+        metadata_keys = datamodule.datasets.predict[0]._metadata_keys  # type: ignore
+        expected_filenames = datamodule.datasets.predict[0]._filenames  # type: ignore
+        grouping_enabled = expected_filenames is not None
+        callback = writers.EmbeddingsWriter(
+            output_dir=output_dir,
+            dataloader_idx_map={0: "train", 1: "val", 2: "test"},
+            backbone=nn.Flatten(),
+            metadata_keys=metadata_keys,
         )
-        all_predictions = trainer.predict(
-            model=model, datamodule=datamodule, return_predictions=True
-        )
-        files = Path(output_dir).glob("*.pt")
-        files = [f.relative_to(output_dir).as_posix() for f in files]
+        trainer = _init_and_run_trainer([callback], model, datamodule)
 
         assert isinstance(trainer.predict_dataloaders, list)
         assert len(trainer.predict_dataloaders) == 3
-        assert isinstance(all_predictions, list)
-        assert len(all_predictions) == 3
-        total_n_predictions = 0
+
+        unique_filenames = set()
+        tot_n_samples = 0
         for dataloader_idx in range(len(trainer.predict_dataloaders)):
+            _check_embedding_dimensions(output_dir, grouping_enabled)
             dataset = trainer.predict_dataloaders[dataloader_idx].dataset
+            filenames = _check_if_embedding_files_exist(output_dir, dataset, expected_filenames)
+            unique_filenames.update(filenames)
+            tot_n_samples += len(dataset)
 
-            # Check if the number of predictions is correct
-            predictions = all_predictions[dataloader_idx]
-            assert isinstance(predictions, list)
-            n_predictions = sum(len(p) for p in predictions)
-            assert len(dataset) == n_predictions
+        expected_file_count = len(unique_filenames) if expected_filenames else tot_n_samples
+        _check_expected_n_files(output_dir, expected_file_count)
+        _check_manifest(output_dir, len(unique_filenames), metadata_keys)
 
-            # Check if the expected files are present
-            for idx in range(len(dataset)):
-                filename = dataset.filename(idx)
-                assert f"{filename}.pt" in files
 
-            total_n_predictions += n_predictions
+def _init_and_run_trainer(
+    callbacks: List[callbacks.Callback],
+    model: pl.LightningModule,
+    datamodule: datamodules.DataModule,
+):
+    """Initializes and runs the trainer with the given callbacks."""
+    trainer = pl.Trainer(
+        logger=False,
+        accelerator="cpu",
+        callbacks=callbacks,
+    )
+    trainer.predict(model=model, datamodule=datamodule, return_predictions=True)
 
-        # Check if the manifest file is in the expected format
-        df_manifest = pd.read_csv(os.path.join(output_dir, "manifest.csv"))
-        assert "origin" in df_manifest.columns
-        assert "embeddings" in df_manifest.columns
-        assert "target" in df_manifest.columns
-        assert "split" in df_manifest.columns
-        assert len(df_manifest) == total_n_predictions
+    return trainer
+
+
+def _check_if_embedding_files_exist(
+    output_dir: str, dataset: datasets.Dataset, expected_filenames: List[str] | None
+) -> Set[str]:
+    """Checks if the expected embedding files exist in the output directory."""
+    output_files = _get_output_filenames(output_dir)
+
+    dataset_filenames = set()
+    for idx in range(len(dataset)):  # type: ignore
+        filename = f"{dataset.filename(idx)}.pt"  # type: ignore
+        assert filename in output_files
+        dataset_filenames.add(filename)
+
+    if expected_filenames:
+        assert len(set(expected_filenames) - {Path(x).stem for x in output_files}) == 0
+
+    return dataset_filenames
+
+
+def _check_embedding_dimensions(output_dir: str, grouping_enabled: bool):
+    """Checks if the produced embeddings have the expected dimensions."""
+    embedding_paths = Path(output_dir).glob("*.pt")
+
+    for path in embedding_paths:
+        tensor = torch.load(path)
+        assert tensor.ndim == 2
+
+        if grouping_enabled:
+            assert tensor.shape[0] > 1
+        else:
+            assert tensor.shape[0] == 1
+
+
+def _check_expected_n_files(output_dir: str, expected_file_count: int):
+    """Checks if the number of produced output files matches the expected count."""
+    output_files = _get_output_filenames(output_dir)
+    assert len(output_files) == expected_file_count
+
+
+def _check_manifest(
+    output_dir: str, expected_n_entries: int, metadata_keys: List[str] | None = None
+):
+    """Checks if the manifest file contains the expected number of entries and columns."""
+    manifest_path = os.path.join(output_dir, "manifest.csv")
+    assert os.path.isfile(manifest_path)
+    df_manifest = pd.read_csv(manifest_path)
+
+    expected_columns = ["origin", "embeddings", "target", "split"] + (metadata_keys or [])
+    for column in expected_columns:
+        assert column in df_manifest.columns
+
+    assert len(df_manifest) == expected_n_entries
+
+    if metadata_keys:
+        assert all(key in df_manifest.columns for key in metadata_keys)
+
+
+def _get_output_filenames(output_dir: str) -> List[str]:
+    """Returns the list of output embedding filenames in the output directory."""
+    output_files = Path(output_dir).glob("*.pt")
+    output_files = [f.relative_to(output_dir).as_posix() for f in output_files]
+    return output_files
 
 
 @pytest.fixture(scope="function")
@@ -87,11 +158,31 @@ def model(n_classes: int = 4) -> modules.HeadModule:
 @pytest.fixture(scope="function")
 def dataset(
     n_samples: int,
+    metadata_keys: List[str] | None,
+    filenames: List[str] | None,
 ) -> List[datasets.Dataset]:
     """Fake dataset fixture."""
-    train_dataset = FakeDataset(split="train", length=n_samples, size=SAMPLE_SHAPE)
-    val_dataset = FakeDataset(split="val", length=n_samples, size=SAMPLE_SHAPE)
-    test_dataset = FakeDataset(split="test", length=n_samples, size=SAMPLE_SHAPE)
+    train_dataset = FakeDataset(
+        split="train",
+        length=n_samples,
+        size=SAMPLE_SHAPE,
+        metadata_keys=metadata_keys,
+        filenames=filenames,
+    )
+    val_dataset = FakeDataset(
+        split="val",
+        length=n_samples,
+        size=SAMPLE_SHAPE,
+        metadata_keys=metadata_keys,
+        filenames=filenames,
+    )
+    test_dataset = FakeDataset(
+        split="test",
+        length=n_samples,
+        size=SAMPLE_SHAPE,
+        metadata_keys=metadata_keys,
+        filenames=filenames,
+    )
 
     return [train_dataset, val_dataset, test_dataset]
 
@@ -99,17 +190,35 @@ def dataset(
 class FakeDataset(boring_classes.RandomDataset, datasets.Dataset):
     """Fake prediction dataset."""
 
-    def __init__(self, split: Literal["train", "val", "test"], size: int = 32, length: int = 10):
+    def __init__(
+        self,
+        split: Literal["train", "val", "test"],
+        size: int = 32,
+        length: int = 10,
+        metadata_keys: List[str] | None = None,
+        filenames: List[str] | None = None,
+    ):
         """Initializes the dataset."""
         super().__init__(size=size, length=length)
         self._split = split
+        self._metadata_keys = metadata_keys
+        self._filenames = filenames
 
     def filename(self, index: int) -> str:
         """Returns the filename for the given index."""
-        return f"{self._split}-{index}"
+        if self._filenames:
+            # This simulates the case where where multiple items can correspond to the same file.
+            # e.g. in WSI classification, multiple patches can belong to the same slide.
+            return random.choice(self._filenames)
+        else:
+            return f"{self._split}-{index}"
 
     @override
     def __getitem__(self, index: int):
         data = boring_classes.RandomDataset.__getitem__(self, index)
         target = random.choice([0, 1])
-        return data, target
+        if self._metadata_keys:
+            metadata = {key: random.choice([0, 1, 2]) for key in self._metadata_keys}
+            return data, target, metadata
+        else:
+            return data, target

--- a/tests/eva/core/callbacks/writers/test_embeddings.py
+++ b/tests/eva/core/callbacks/writers/test_embeddings.py
@@ -1,5 +1,6 @@
 """Tests the embeddings writer."""
 
+import functools
 import os
 import random
 import tempfile
@@ -162,27 +163,16 @@ def dataset(
     filenames: List[str] | None,
 ) -> List[datasets.Dataset]:
     """Fake dataset fixture."""
-    train_dataset = FakeDataset(
-        split="train",
+    Dataset = functools.partial(
+        FakeDataset,
         length=n_samples,
         size=SAMPLE_SHAPE,
         metadata_keys=metadata_keys,
         filenames=filenames,
     )
-    val_dataset = FakeDataset(
-        split="val",
-        length=n_samples,
-        size=SAMPLE_SHAPE,
-        metadata_keys=metadata_keys,
-        filenames=filenames,
-    )
-    test_dataset = FakeDataset(
-        split="test",
-        length=n_samples,
-        size=SAMPLE_SHAPE,
-        metadata_keys=metadata_keys,
-        filenames=filenames,
-    )
+    train_dataset = Dataset(split="train")
+    val_dataset = Dataset(split="val")
+    test_dataset = Dataset(split="test")
 
     return [train_dataset, val_dataset, test_dataset]
 


### PR DESCRIPTION
Closes #376 

- Implemented support for adding multiple embeddings to the same `.pt` if they share the same filename (e.g. slide_id)
- Made `EmbeddingsWriter` agnostic to WSI's by replacing slide_id field extraction by generic `metadata_keys`
- Refactored & updated unit tests

This helps to prevent the explosion of the number of files for slide level tasks, where you can have thousands of patch embeddings per slide. Each slide now results in a single `.pt` file of shape `[n_patches, embedding_dim]`.