### PR TITLE
Replace `cached_property` in `WsiDataset` by LRU cache

### DIFF
--- a/src/eva/vision/data/datasets/wsi.py
+++ b/src/eva/vision/data/datasets/wsi.py
@@ -1,7 +1,6 @@
 """Dataset classes for whole-slide images."""
 
 import os
-from functools import cached_property
 from typing import Callable, Dict
 
 import pandas as pd
@@ -11,7 +10,6 @@ from typing_extensions import override
 
 from eva.vision.data import wsi
 from eva.vision.data.datasets import vision
-from eva.vision.data.wsi.backends import wsi_backend
 from eva.vision.data.wsi.patching import samplers
 
 
@@ -55,20 +53,19 @@ class WsiDataset(vision.VisionDataset):
     def filename(self, index: int) -> str:
         return f"{self._file_path}_{index}"
 
-    @cached_property
+    @property
     def _wsi(self) -> wsi.Wsi:
-        # wsi_obj = wsi.get_wsi_class(self._backend)(self._file_path)
-        return wsi_backend(self._backend)(self._file_path)
+        return wsi.get_cached_wsi(self._file_path, self._backend)
 
-    @cached_property
+    @property
     def _coords(self) -> wsi.PatchCoordinates:
-        return wsi.PatchCoordinates.from_file(
-            wsi_path=self._file_path,
+        return wsi.get_cached_coords(
+            file_path=self._file_path,
             width=self._width,
             height=self._height,
             target_mpp=self._target_mpp,
-            backend=self._backend,
             sampler=self._sampler,
+            backend=self._backend,
         )
 
     @override

--- a/src/eva/vision/data/wsi/__init__.py
+++ b/src/eva/vision/data/wsi/__init__.py
@@ -1,6 +1,6 @@
 """WSI API."""
 
-from eva.vision.data.wsi.backends import Wsi, wsi_backend
-from eva.vision.data.wsi.patching.coordinates import PatchCoordinates
+from eva.vision.data.wsi.backends import Wsi, get_cached_wsi, wsi_backend
+from eva.vision.data.wsi.patching.coordinates import PatchCoordinates, get_cached_coords
 
-__all__ = ["Wsi", "PatchCoordinates", "wsi_backend"]
+__all__ = ["Wsi", "PatchCoordinates", "get_cached_coords", "wsi_backend", "get_cached_wsi"]

--- a/src/eva/vision/data/wsi/backends/__init__.py
+++ b/src/eva/vision/data/wsi/backends/__init__.py
@@ -1,9 +1,12 @@
 """WSI Backends API."""
 
+import functools
 import importlib.util
 from typing import Callable
 
 from eva.vision.data.wsi.backends.base import Wsi
+
+LRU_CACHE_SIZE = 32
 
 
 def is_openslide_available() -> bool:
@@ -28,4 +31,10 @@ def wsi_backend(backend: str = "openslide") -> Callable[..., Wsi]:
             raise ValueError(f"Unknown WSI backend selected: {backend}")
 
 
-__all__ = ["Wsi", "wsi_backend", "is_openslide_available"]
+@functools.lru_cache(LRU_CACHE_SIZE)
+def get_cached_wsi(file_path: str, backend: str) -> Wsi:
+    """Returns a cached instance of the whole-slide image backend reader."""
+    return wsi_backend(backend)(file_path)
+
+
+__all__ = ["Wsi", "wsi_backend", "get_cached_wsi", "is_openslide_available"]

--- a/src/eva/vision/data/wsi/patching/coordinates.py
+++ b/src/eva/vision/data/wsi/patching/coordinates.py
@@ -1,10 +1,13 @@
 """A module for handling coordinates of patches from a whole-slide image."""
 
 import dataclasses
+import functools
 from typing import List, Tuple
 
 from eva.vision.data.wsi import backends
 from eva.vision.data.wsi.patching import samplers
+
+LRU_CACHE_SIZE = 32
 
 
 @dataclasses.dataclass
@@ -56,3 +59,23 @@ class PatchCoordinates:
             x_y.append((x, y))
 
         return cls(x_y, scaled_width, scaled_height, level_idx)
+
+
+@functools.lru_cache(LRU_CACHE_SIZE)
+def get_cached_coords(
+    file_path: str,
+    width: int,
+    height: int,
+    target_mpp: float,
+    sampler: samplers.Sampler,
+    backend: str,
+) -> PatchCoordinates:
+    """Get a cached instance of PatchCoordinates for the specified parameters."""
+    return PatchCoordinates.from_file(
+        wsi_path=file_path,
+        width=width,
+        height=height,
+        target_mpp=target_mpp,
+        backend=backend,
+        sampler=sampler,
+    )


### PR DESCRIPTION
Closes #387 

Tested using 10k WSIs with 100 patches each using a dataloader with 10 workers. With this fix the memory doesn't build up anymore:
<img width="1017" alt="image" src="https://github.com/kaiko-ai/eva/assets/36882833/4e07294c-22f1-4229-9e50-6fd931bf9d27">

