### PR TITLE
Update WSI foreground segmentation algorithm

### DIFF
--- a/src/eva/vision/data/wsi/__init__.py
+++ b/src/eva/vision/data/wsi/__init__.py
@@ -2,5 +2,15 @@
 
 from eva.vision.data.wsi.backends import Wsi, get_cached_wsi, wsi_backend
 from eva.vision.data.wsi.patching.coordinates import PatchCoordinates, get_cached_coords
+from eva.vision.data.wsi.patching.mask import Mask, get_mask, get_mask_level
 
-__all__ = ["Wsi", "PatchCoordinates", "get_cached_coords", "wsi_backend", "get_cached_wsi"]
+__all__ = [
+    "Wsi",
+    "PatchCoordinates",
+    "Mask",
+    "get_cached_coords",
+    "wsi_backend",
+    "get_cached_wsi",
+    "get_mask",
+    "get_mask_level",
+]

--- a/tests/eva/vision/data/wsi/patching/test_mask.py
+++ b/tests/eva/vision/data/wsi/patching/test_mask.py
@@ -1,0 +1,91 @@
+"""WSI foreground mask tests."""
+
+import os
+
+import numpy as np
+import pytest
+
+from eva.vision.data import wsi as eva_wsi
+
+DEFAULT_ARGS = {
+    "saturation_threshold": 20,
+    "median_blur_threshold": 7,
+    "fill_holes": False,
+    "use_otsu": False,
+    "kernel_size": (7, 7),
+}
+
+
+@pytest.mark.parametrize(
+    "mask_level_idx, mask_args",
+    [
+        (0, DEFAULT_ARGS),
+        (1, DEFAULT_ARGS),
+        (0, DEFAULT_ARGS | {"median_blur_threshold": None}),
+        (0, DEFAULT_ARGS | {"fill_holes": True}),
+        (0, DEFAULT_ARGS | {"use_otsu": True}),
+        (0, DEFAULT_ARGS | {"fill_holes": True, "use_otsu": True}),
+    ],
+)
+def test_get_mask(wsi: eva_wsi.Wsi, mask_level_idx: int, mask_args: dict):
+    """Tests the foreground mask generation with different configurations."""
+    mask = eva_wsi.get_mask(wsi, mask_level_idx=0, **mask_args)
+
+    assert isinstance(mask, eva_wsi.Mask)
+    assert isinstance(mask.mask_array, np.ndarray)
+    assert mask.mask_array.shape == wsi.level_dimensions[mask.mask_level_idx]
+    assert np.all(np.isin(mask.mask_array, [0, 1]))
+
+    if mask.mask_level_idx == 0:
+        assert mask.scale_factors == (1.0, 1.0)
+    elif mask_level_idx == 1:
+        assert mask.scale_factors == (0.5, 0.5)
+
+
+@pytest.mark.parametrize(
+    "width, height, target_mpp, expected_level",
+    [
+        (4, 4, 0.25, 0),
+        (16, 16, 0.05, 0),
+        (4, 4, 0.5, 1),
+    ],
+)
+def test_get_mask_level(
+    wsi: eva_wsi.Wsi, width: int, height: int, target_mpp: float, expected_level: int
+):
+    """Tests the selection of the mask level based on the patch dimensions."""
+    level = eva_wsi.get_mask_level(wsi, width, height, target_mpp)
+    assert level == expected_level
+
+
+@pytest.mark.parametrize(
+    "width, height, target_mpp",
+    [
+        (4, 4, 0.1),
+        (16, 16, 0.01),
+        (2, 2, 0.25),
+    ],
+)
+def test_no_suitable_level_available(wsi: eva_wsi.Wsi, width: int, height: int, target_mpp: float):
+    """Tests the case where no suitable mask level is available.
+
+    This can happen for instance when the patch dimensions scaled to the selected mask level
+    are too small or even collapse to zero pixels.
+    """
+    with pytest.raises(
+        ValueError, match="No level with the specified minimum number of patch pixels available."
+    ):
+        eva_wsi.get_mask_level(wsi, width, height, target_mpp)
+
+
+@pytest.fixture
+def wsi(assets_path: str) -> eva_wsi.Wsi:
+    """Fixture for loading a WSI object.
+
+    The test WSI slide has the following specs:
+    - level_dimensions: ((256, 256), (128, 128))
+    - level_downsamples: (1.0, 2.0)
+    - mpp (level 0): 0.25
+    """
+    path = os.path.join(assets_path, "vision/datasets/wsi/0/a.tiff")
+    return eva_wsi.wsi_backend("openslide")(path)


### PR DESCRIPTION
Closes #455

I used a simplified version of the segmentation algorithm from [CLAM](https://github.com/mahmoodlab/CLAM). CLAM on top of what is implemented here filters the approximate contours of the detected foreground objects based on an area threshold as a post processing step. We don't need this step here, because our patching logic anyways applies another foreground threshold filter to the sampled patches, so very small foreground areas in the mask most likely won't yield patches anyways. 

## Comparison
- "grayscale-threshold" is what we've been using so far (for datasets such as panda which have a clean white background this worked reasonably well, but it breaks for datasets such as camelyon16 where this is not the case)
- mb stands for median blur applied to saturation channel in HSV image
- otsu thresholding applied to saturation channel doesn't seem to perform better than using a fixed threshold
- I would recommend disabling the `fill_holes` in our default setup, as filled holes can result in patches sampled from within holes which might not contain relevant tissue data.

<img width="1362" alt="image" src="https://github.com/kaiko-ai/eva/assets/36882833/48523cf9-afa2-40f7-8bfa-24aa0ddb266e">


### Avg Runtime per WSI [s]
grayscale_threshold    0.089027
hsv              0.071794
hsv + mb            0.138696
hsv + mb + holes         0.140928
hsv + mb + otsu               0.138782
hsv + mb + otsu + holes   0.143519

- median blur is computationally the most expensive step, but it generates cleaner and smoother masks. 138ms per WSI is still fast enough, so I recommend to enable it.



