### PR TITLE
updated camelyon16 configs to save embeddings less frequent

### DIFF
--- a/configs/vision/dino_vit/offline/camelyon16.yaml
+++ b/configs/vision/dino_vit/offline/camelyon16.yaml
@@ -25,6 +25,7 @@ trainer:
       - class_path: eva.callbacks.ClassificationEmbeddingsWriter
         init_args:
           output_dir: &DATASET_EMBEDDINGS_ROOT ${oc.env:EMBEDDINGS_ROOT, ./data/embeddings/${oc.env:DINO_BACKBONE, dino_vits16}/camelyon16}
+          save_every_n: 10_000
           dataloader_idx_map:
             0: train
             1: val

--- a/configs/vision/owkin/phikon/offline/camelyon16.yaml
+++ b/configs/vision/owkin/phikon/offline/camelyon16.yaml
@@ -25,6 +25,7 @@ trainer:
       - class_path: eva.callbacks.ClassificationEmbeddingsWriter
         init_args:
           output_dir: &DATASET_EMBEDDINGS_ROOT ${oc.env:EMBEDDINGS_ROOT, ./data/embeddings/owkin/phikon/camelyon16}
+          save_every_n: 10_000
           dataloader_idx_map:
             0: train
             1: val


### PR DESCRIPTION
closes https://github.com/kaiko-ai/eva/issues/537

Note: memory still builds up during predict and accumulates across dataloaders/splits. However, ray node does not crash anymore with example camelyon16/phikon