### PR TITLE
Change `overwrite` default value to True in `EmbeddingWriter`

### DIFF
--- a/configs/vision/dino_vit/offline/bach.yaml
+++ b/configs/vision/dino_vit/offline/bach.yaml
@@ -39,6 +39,7 @@ trainer:
                 pretrained: ${oc.env:PRETRAINED, true}
                 force_reload: ${oc.env:FORCE_RELOAD, false}
               checkpoint_path: ${oc.env:CHECKPOINT_PATH, null}
+          overwrite: false
     logger:
       - class_path: lightning.pytorch.loggers.TensorBoardLogger
         init_args:

--- a/configs/vision/dino_vit/offline/camelyon16.yaml
+++ b/configs/vision/dino_vit/offline/camelyon16.yaml
@@ -41,6 +41,7 @@ trainer:
                 pretrained: ${oc.env:PRETRAINED, true}
                 force_reload: ${oc.env:FORCE_RELOAD, false}
               checkpoint_path: ${oc.env:CHECKPOINT_PATH, null}
+          overwrite: false
     logger:
       - class_path: lightning.pytorch.loggers.TensorBoardLogger
         init_args:

--- a/configs/vision/dino_vit/offline/crc.yaml
+++ b/configs/vision/dino_vit/offline/crc.yaml
@@ -39,6 +39,7 @@ trainer:
                 pretrained: ${oc.env:PRETRAINED, true}
                 force_reload: ${oc.env:FORCE_RELOAD, false}
               checkpoint_path: ${oc.env:CHECKPOINT_PATH, null}
+          overwrite: false
     logger:
       - class_path: lightning.pytorch.loggers.TensorBoardLogger
         init_args:

--- a/configs/vision/dino_vit/offline/mhist.yaml
+++ b/configs/vision/dino_vit/offline/mhist.yaml
@@ -39,6 +39,7 @@ trainer:
                 pretrained: ${oc.env:PRETRAINED, true}
                 force_reload: ${oc.env:FORCE_RELOAD, false}
               checkpoint_path: ${oc.env:CHECKPOINT_PATH, null}
+          overwrite: false
     logger:
       - class_path: lightning.pytorch.loggers.TensorBoardLogger
         init_args:

--- a/configs/vision/dino_vit/offline/panda.yaml
+++ b/configs/vision/dino_vit/offline/panda.yaml
@@ -40,6 +40,7 @@ trainer:
                 pretrained: ${oc.env:PRETRAINED, true}
                 force_reload: ${oc.env:FORCE_RELOAD, false}
               checkpoint_path: ${oc.env:CHECKPOINT_PATH, null}
+          overwrite: false
     logger:
       - class_path: lightning.pytorch.loggers.TensorBoardLogger
         init_args:

--- a/configs/vision/dino_vit/offline/patch_camelyon.yaml
+++ b/configs/vision/dino_vit/offline/patch_camelyon.yaml
@@ -40,6 +40,7 @@ trainer:
                 pretrained: ${oc.env:PRETRAINED, true}
                 force_reload: ${oc.env:FORCE_RELOAD, false}
               checkpoint_path: ${oc.env:CHECKPOINT_PATH, null}
+          overwrite: false
     logger:
       - class_path: lightning.pytorch.loggers.TensorBoardLogger
         init_args:

--- a/src/eva/core/callbacks/writers/embeddings/_manifest.py
+++ b/src/eva/core/callbacks/writers/embeddings/_manifest.py
@@ -39,9 +39,8 @@ class ManifestManager:
         manifest_path = os.path.join(self._output_dir, "manifest.csv")
         if os.path.exists(manifest_path) and not self._overwrite:
             raise FileExistsError(
-                f"Manifest file already exists at {manifest_path}. This likely means that the "
-                "embeddings have been computed before. Consider using `eva fit` instead "
-                "of `eva predict_fit` or `eva predict`."
+                f"A manifest file already exists at {manifest_path}, which indicates that the "
+                "chosen output directory has been previously used for writing embeddings."
             )
 
         self._manifest_file = open(manifest_path, "w", newline="")

--- a/src/eva/core/callbacks/writers/embeddings/base.py
+++ b/src/eva/core/callbacks/writers/embeddings/base.py
@@ -168,18 +168,16 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter, abc.ABC):
 
     def _check_if_exists(self) -> None:
         """Checks if the output directory already exists and if it should be overwritten."""
-        exists = (
-            os.path.isdir(self._output_dir) and len(list(Path(self._output_dir).rglob("*.pt"))) > 0
-        )
-        if exists and not self._overwrite:
+        try:
+            os.makedirs(self._output_dir, exist_ok=self._overwrite)
+        except FileExistsError as e:
             raise FileExistsError(
-                f"Embeddings already exists in {self._output_dir}. This either means that they "
-                "have been computed before or that a wrong output directory is being used. "
-                "Consider using `eva fit` instead, selecting a different output directory or "
-                "setting overwrite=True."
+                f"The embeddings output directory already exists: {self._output_dir}. This "
+                "either means that they have been computed before or that a wrong output "
+                "directory is being used. Consider using `eva fit` instead, selecting a "
+                "different output directory or setting overwrite=True."
             )
-        else:
-            os.makedirs(self._output_dir, exist_ok=True)
+        os.makedirs(self._output_dir, exist_ok=True)
 
 
 def _as_io_buffers(*items: torch.Tensor) -> Sequence[io.BytesIO]:

--- a/src/eva/core/callbacks/writers/embeddings/base.py
+++ b/src/eva/core/callbacks/writers/embeddings/base.py
@@ -3,7 +3,6 @@
 import abc
 import io
 import os
-from pathlib import Path
 from typing import Any, Dict, List, Sequence
 
 import lightning.pytorch as pl
@@ -176,7 +175,7 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter, abc.ABC):
                 "either means that they have been computed before or that a wrong output "
                 "directory is being used. Consider using `eva fit` instead, selecting a "
                 "different output directory or setting overwrite=True."
-            )
+            ) from e
         os.makedirs(self._output_dir, exist_ok=True)
 
 

--- a/src/eva/core/callbacks/writers/embeddings/base.py
+++ b/src/eva/core/callbacks/writers/embeddings/base.py
@@ -167,7 +167,7 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter, abc.ABC):
         return item_metadata
 
     def _check_if_exists(self) -> None:
-        """Checks if a file or directory exists."""
+        """Checks if the output directory already exists and if it should be overwritten."""
         exists = (
             os.path.isdir(self._output_dir) and len(list(Path(self._output_dir).rglob("*.pt"))) > 0
         )

--- a/src/eva/core/callbacks/writers/embeddings/base.py
+++ b/src/eva/core/callbacks/writers/embeddings/base.py
@@ -3,6 +3,7 @@
 import abc
 import io
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Sequence
 
 import lightning.pytorch as pl
@@ -26,7 +27,7 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter, abc.ABC):
         backbone: nn.Module | None = None,
         dataloader_idx_map: Dict[int, str] | None = None,
         metadata_keys: List[str] | None = None,
-        overwrite: bool = True,
+        overwrite: bool = False,
         save_every_n: int = 100,
     ) -> None:
         """Initializes a new EmbeddingsWriter instance.
@@ -42,7 +43,9 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter, abc.ABC):
                 names (e.g. train, val, test).
             metadata_keys: An optional list of keys to extract from the batch metadata and store
                 as additional columns in the manifest file.
-            overwrite: Whether to overwrite the output directory.
+            overwrite: Whether to overwrite if embeddings are already present in the specified
+                output directory. If set to `False`, an error will be raised if embeddings are
+                already present (recommended).
             save_every_n: Interval for number of iterations to save the embeddings to disk.
                 During this interval, the embeddings are accumulated in memory.
         """
@@ -75,7 +78,7 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter, abc.ABC):
 
     @override
     def on_predict_start(self, trainer: pl.Trainer, pl_module: pl.LightningModule) -> None:
-        os.makedirs(self._output_dir, exist_ok=self._overwrite)
+        self._check_if_exists()
         self._initialize_write_process()
         self._write_process.start()
 
@@ -162,6 +165,21 @@ class EmbeddingsWriter(callbacks.BasePredictionWriter, abc.ABC):
             item_metadata[key] = metadata[key][local_idx]
 
         return item_metadata
+
+    def _check_if_exists(self) -> None:
+        """Checks if a file or directory exists."""
+        exists = (
+            os.path.isdir(self._output_dir) and len(list(Path(self._output_dir).rglob("*.pt"))) > 0
+        )
+        if exists and not self._overwrite:
+            raise FileExistsError(
+                f"Embeddings already exists in {self._output_dir}. This either means that they "
+                "have been computed before or that a wrong output directory is being used. "
+                "Consider using `eva fit` instead, selecting a different output directory or "
+                "setting overwrite=True."
+            )
+        else:
+            os.makedirs(self._output_dir, exist_ok=True)
 
 
 def _as_io_buffers(*items: torch.Tensor) -> Sequence[io.BytesIO]:

--- a/tests/eva/core/callbacks/writers/embeddings/test_classification.py
+++ b/tests/eva/core/callbacks/writers/embeddings/test_classification.py
@@ -47,6 +47,7 @@ def test_embeddings_writer(datamodule: datamodules.DataModule, model: modules.He
             dataloader_idx_map={0: "train", 1: "val", 2: "test"},
             backbone=nn.Flatten(),
             metadata_keys=metadata_keys,
+            overwrite=True,
         )
         trainer = _init_and_run_trainer([callback], model, datamodule)
 


### PR DESCRIPTION
Closes #557 

Enabling overwriting embeddings by default is risky, as users might unintentionally overwrite previously computed embeddings.