### PR TITLE
Add option to load `model_kwargs` from env variable

### DIFF
--- a/configs/vision/pathology/offline/segmentation/consep.yaml
+++ b/configs/vision/pathology/offline/segmentation/consep.yaml
@@ -37,8 +37,7 @@ trainer:
             class_path: eva.vision.models.wrappers.VisionBackbone
             init_args:
               model_name: ${oc.env:MODEL_NAME, universal/vit_small_patch16_224_imagenet}
-              model_kwargs:
-                out_indices: ${oc.env:OUT_INDICES, 1}
+              model_kwargs: '${oc.env:MODEL_KWARGS, "{\"out_indices\": ${oc.env:OUT_INDICES, 1}}"}'
     logger:
       - class_path: lightning.pytorch.loggers.TensorBoardLogger
         init_args:

--- a/src/eva/vision/models/networks/backbones/universal/vit.py
+++ b/src/eva/vision/models/networks/backbones/universal/vit.py
@@ -59,7 +59,7 @@ def vit_small_patch16_224_imagenet(
 
 @register_model("universal/vit_timm")
 def vit_timm(
-    model_name: str | None = None,
+    timm_model_name: str | None = None,
     checkpoint_path: str | None = None,
     pretrained: bool = False,
     dynamic_img_size: bool = True,
@@ -72,8 +72,8 @@ def vit_timm(
     the default configuration files.
 
     Args:
-        model_name: The name of the model to load. If not specified, will
-            load from the environment variable `TIMM_MODEL_NAME`.
+        timm_model_name: The name of the model to load from timm. If not specified,
+            will load from the environment variable `TIMM_MODEL_NAME`.
         checkpoint_path: The path to the checkpoint file. If not specified,
             will load from the environment variable `CHECKPOINT_PATH`.
         pretrained: If set to `True`, load pretrained ImageNet-1k weights.
@@ -84,16 +84,16 @@ def vit_timm(
     Returns:
         The VIT model instance.
     """
-    model_name = model_name or os.getenv("TIMM_MODEL_NAME")
+    timm_model_name = timm_model_name or os.getenv("TIMM_MODEL_NAME")
     checkpoint_path = checkpoint_path or os.getenv("CHECKPOINT_PATH")
-    if not model_name:
+    if not timm_model_name:
         raise ValueError("No model_name is set.")
     if checkpoint_path and not os.path.exists(checkpoint_path):
         raise FileNotFoundError(f"Checkpoint file {checkpoint_path} does not exist.")
 
-    logger.info(f"Loading timm model {model_name} from checkpoint {checkpoint_path}")
+    logger.info(f"Loading timm model {timm_model_name} from checkpoint {checkpoint_path}")
     return wrappers.TimmModel(
-        model_name=model_name,
+        model_name=timm_model_name,
         checkpoint_path=checkpoint_path or "",
         pretrained=pretrained,
         out_indices=out_indices,


### PR DESCRIPTION
Example:
```
MODEL_NAME=universal/vit_timm \
MODEL_KWARGS='{"out_indices": 1, "timm_model_name": "vit_small_patch16_224.dino", "checkpoint_path": "path/to/model.ckpt"}' \
eva predict_fit --config configs/vision/pathology/offline/segmentation/consep.yaml
```