### PR TITLE
Make `backbone` config overwritable

### DIFF
--- a/configs/core/tests/offline/embeddings.yaml
+++ b/configs/core/tests/offline/embeddings.yaml
@@ -1,4 +1,6 @@
 ---
+backbone:
+  class_path: torch.nn.Flatten
 trainer:
   class_path: eva.Trainer
   init_args:

--- a/configs/vision/backbones/from_registry.yaml
+++ b/configs/vision/backbones/from_registry.yaml
@@ -1,0 +1,7 @@
+---
+backbone:
+  class_path: eva.vision.models.wrappers.VisionBackbone
+  init_args:
+    model_name: ${oc.env:MODEL_NAME}
+    model_kwargs:
+      out_indices: ${oc.env:OUT_INDICES, null}

--- a/configs/vision/pathology/offline/segmentation/consep.yaml
+++ b/configs/vision/pathology/offline/segmentation/consep.yaml
@@ -1,4 +1,13 @@
 ---
+backbone:
+  class_path: eva.vision.models.wrappers.TimmModel
+  init_args:
+    model_name: ${oc.env:MODEL_NAME, vit_small_patch16_224_dino}
+    checkpoint_path: ${oc.env:CHECKPOINT_PATH, null}
+    pretrained: ${oc.env:PRETRAINED, true}
+    out_indices: ${oc.env:OUT_INDICES, 1}
+    model_kwargs:
+      dynamic_img_size: true
 trainer:
   class_path: eva.Trainer
   init_args:
@@ -33,12 +42,7 @@ trainer:
             1: val
           metadata_keys: ["coords"]
           overwrite: true
-          backbone:
-            class_path: eva.vision.models.wrappers.VisionBackbone
-            init_args:
-              model_name: ${oc.env:MODEL_NAME, universal/vit_small_patch16_224_imagenet}
-              model_kwargs:
-                out_indices: ${oc.env:OUT_INDICES, 1}
+          backbone: ${backbone}
     logger:
       - class_path: lightning.pytorch.loggers.TensorBoardLogger
         init_args:

--- a/configs/vision/tests/offline/panda.yaml
+++ b/configs/vision/tests/offline/panda.yaml
@@ -1,4 +1,13 @@
 ---
+backbone:
+  class_path: eva.models.ModelFromFunction
+  init_args:
+    path: torch.hub.load
+    arguments:
+      repo_or_dir: facebookresearch/dino:main
+      model: dino_vits16
+      pretrained: false
+    checkpoint_path: &CHECKPOINT_PATH ${oc.env:CHECKPOINT_PATH, null}
 trainer:
   class_path: eva.Trainer
   init_args:
@@ -15,15 +24,7 @@ trainer:
             1: val
             2: test
           metadata_keys: ["wsi_id"]
-          backbone:
-            class_path: eva.models.ModelFromFunction
-            init_args:
-              path: torch.hub.load
-              arguments:
-                repo_or_dir: facebookresearch/dino:main
-                model: dino_vits16
-                pretrained: false
-              checkpoint_path: &CHECKPOINT_PATH ${oc.env:CHECKPOINT_PATH, null}
+          backbone: ${backbone}
 model:
   class_path: eva.HeadModule
   init_args:

--- a/configs/vision/tests/offline/patch_camelyon.yaml
+++ b/configs/vision/tests/offline/patch_camelyon.yaml
@@ -1,4 +1,13 @@
 ---
+backbone:
+  class_path: eva.models.ModelFromFunction
+  init_args:
+    path: torch.hub.load
+    arguments:
+      repo_or_dir: facebookresearch/dino:main
+      model: dino_vits16
+      pretrained: false
+    checkpoint_path: &CHECKPOINT_PATH ${oc.env:CHECKPOINT_PATH, null}
 trainer:
   class_path: eva.Trainer
   init_args:
@@ -15,15 +24,7 @@ trainer:
             0: train
             1: val
             2: test
-          backbone:
-            class_path: eva.models.ModelFromFunction
-            init_args:
-              path: torch.hub.load
-              arguments:
-                repo_or_dir: facebookresearch/dino:main
-                model: dino_vits16
-                pretrained: false
-              checkpoint_path: &CHECKPOINT_PATH ${oc.env:CHECKPOINT_PATH, null}
+          backbone: ${backbone}
       - class_path: lightning.pytorch.callbacks.ModelCheckpoint
         init_args:
           filename: best

--- a/configs/vision/tests/online/patch_camelyon.yaml
+++ b/configs/vision/tests/online/patch_camelyon.yaml
@@ -1,4 +1,6 @@
 ---
+backbone:
+  class_path: torch.nn.Flatten
 trainer:
   class_path: eva.Trainer
   init_args:
@@ -9,8 +11,7 @@ trainer:
 model:
   class_path: eva.HeadModule
   init_args:
-    backbone:
-      class_path: torch.nn.Flatten
+    backbone: ${backbone}
     head:
       class_path: torch.nn.Linear
       init_args:

--- a/src/eva/core/interface/interface.py
+++ b/src/eva/core/interface/interface.py
@@ -1,5 +1,7 @@
 """Main interface class."""
 
+from torch import nn
+
 from eva.core import trainers as eva_trainer
 from eva.core.data import datamodules
 from eva.core.models import modules
@@ -14,6 +16,7 @@ class Interface:
 
     def fit(
         self,
+        backbone: nn.Module,
         trainer: eva_trainer.Trainer,
         model: modules.ModelModule,
         data: datamodules.DataModule,
@@ -30,14 +33,16 @@ class Interface:
         - Fitting only the head network using a dataset that loads pre-computed embeddings.
 
         Args:
-            trainer: The base trainer to use but not modify.
-            model: The model module to use but not modify.
+            backbone: The backbone model to use.
+            trainer: The base trainer to use.
+            model: The model module to use.
             data: The data module.
         """
         trainer.run_evaluation_session(model=model, datamodule=data)
 
     def predict(
         self,
+        backbone: nn.Module,
         trainer: eva_trainer.Trainer,
         model: modules.ModelModule,
         data: datamodules.DataModule,
@@ -47,8 +52,9 @@ class Interface:
         This method performs inference with a pre-trained foundation model to compute embeddings.
 
         Args:
-            trainer: The base trainer to use but not modify.
-            model: The model module to use but not modify.
+            backbone: The backbone model to use.
+            trainer: The base trainer to use.
+            model: The model module to use.
             data: The data module.
         """
         eva_trainer.infer_model(
@@ -60,6 +66,7 @@ class Interface:
 
     def predict_fit(
         self,
+        backbone: nn.Module,
         trainer: eva_trainer.Trainer,
         model: modules.ModelModule,
         data: datamodules.DataModule,
@@ -71,9 +78,10 @@ class Interface:
         2. fit: training the head network using the embeddings generated in step 1.
 
         Args:
-            trainer: The base trainer to use but not modify.
-            model: The model module to use but not modify.
+            backbone: The backbone model to use.
+            trainer: The base trainer to use.
+            model: The model module to use.
             data: The data module.
         """
-        self.predict(trainer=trainer, model=model, data=data)
-        self.fit(trainer=trainer, model=model, data=data)
+        self.predict(backbone=backbone, trainer=trainer, model=model, data=data)
+        self.fit(backbone=backbone, trainer=trainer, model=model, data=data)

--- a/src/eva/core/utils/io/__init__.py
+++ b/src/eva/core/utils/io/__init__.py
@@ -1,6 +1,5 @@
 """Core I/O utilities."""
 
 from eva.core.utils.io.dataframe import read_dataframe
-from eva.core.utils.io.yaml import save_yaml
 
-__all__ = ["read_dataframe", "save_yaml"]
+__all__ = ["read_dataframe"]

--- a/src/eva/core/utils/io/__init__.py
+++ b/src/eva/core/utils/io/__init__.py
@@ -1,5 +1,6 @@
 """Core I/O utilities."""
 
 from eva.core.utils.io.dataframe import read_dataframe
+from eva.core.utils.io.yaml import save_yaml
 
-__all__ = ["read_dataframe"]
+__all__ = ["read_dataframe", "save_yaml"]

--- a/src/eva/core/utils/io/yaml.py
+++ b/src/eva/core/utils/io/yaml.py
@@ -1,32 +1,6 @@
 """YAML related I/O operations."""
 
-import functools
-from pathlib import Path
-from typing import Any
-
 import omegaconf
-
-
-@functools.singledispatch
-def save_yaml(data: Any, save_path: str) -> None:
-    """Save data to a YAML file.
-
-    Args:
-        data: Data to be saved
-        save_path: Path to save the data
-    """
-    raise TypeError(f"Unsupported type: {type(data)}.")
-
-
-@save_yaml.register
-def _(
-    data: omegaconf.DictConfig | omegaconf.ListConfig, save_path: str, resolve: bool = False
-) -> None:
-    """Save OmegaConf DictConfig to a YAML file."""
-    Path(save_path).parent.mkdir(parents=True, exist_ok=True)
-    with open(save_path, "w") as file:
-        data_yaml = omegaconf.OmegaConf.to_yaml(data, resolve=resolve)
-        file.write(data_yaml)
 
 
 def update_keys(

--- a/src/eva/core/utils/io/yaml.py
+++ b/src/eva/core/utils/io/yaml.py
@@ -1,0 +1,57 @@
+"""YAML related I/O operations."""
+
+import functools
+from pathlib import Path
+from typing import Any
+
+import omegaconf
+
+
+@functools.singledispatch
+def save_yaml(data: Any, save_path: str) -> None:
+    """Save data to a YAML file.
+
+    Args:
+        data: Data to be saved
+        save_path: Path to save the data
+    """
+    raise TypeError(f"Unsupported type: {type(data)}.")
+
+
+@save_yaml.register
+def _(
+    data: omegaconf.DictConfig | omegaconf.ListConfig, save_path: str, resolve: bool = False
+) -> None:
+    """Save OmegaConf DictConfig to a YAML file."""
+    Path(save_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(save_path, "w") as file:
+        data_yaml = omegaconf.OmegaConf.to_yaml(data, resolve=resolve)
+        file.write(data_yaml)
+
+
+def update_keys(
+    yaml_path_a: str, yaml_path_b: str, merge: bool = False, resolve: bool = False
+) -> str:
+    """Updates the keys of a YAML file with the values from another YAML file.
+
+    Args:
+        yaml_path_a: Path to the base YAML file
+        yaml_path_b: Path to the YAML file with the keys to be updated
+        merge: Whether to merge the values of the keys or replace them
+        resolve: Whether to resolve the references in the YAML file
+
+    Return:
+        str: Updated YAML as string
+    """
+    config = omegaconf.OmegaConf.load(yaml_path_a)
+    override = omegaconf.OmegaConf.load(yaml_path_b)
+
+    if not isinstance(config, omegaconf.DictConfig) or not isinstance(
+        override, omegaconf.DictConfig
+    ):
+        raise TypeError("Only yaml files in dict format are supported.")
+
+    for key in override.keys():
+        omegaconf.OmegaConf.update(config, key, override[key], merge=merge)  # type: ignore
+
+    return omegaconf.OmegaConf.to_yaml(config, resolve=resolve)

--- a/src/eva/vision/models/networks/backbones/universal/__init__.py
+++ b/src/eva/vision/models/networks/backbones/universal/__init__.py
@@ -3,7 +3,6 @@
 from eva.vision.models.networks.backbones.universal.vit import (
     vit_small_patch16_224_imagenet,
     vit_small_patch16_224_random,
-    vit_timm,
 )
 
-__all__ = ["vit_small_patch16_224_imagenet", "vit_small_patch16_224_random", "vit_timm"]
+__all__ = ["vit_small_patch16_224_imagenet", "vit_small_patch16_224_random"]

--- a/src/eva/vision/models/networks/backbones/universal/vit.py
+++ b/src/eva/vision/models/networks/backbones/universal/vit.py
@@ -1,13 +1,10 @@
 """Vision Transformers base universal backbones."""
 
-import os
 from typing import Tuple
 
 import timm
-from loguru import logger
 from torch import nn
 
-from eva.vision.models import wrappers
 from eva.vision.models.networks.backbones.registry import register_model
 
 
@@ -54,50 +51,4 @@ def vit_small_patch16_224_imagenet(
         features_only=out_indices is not None,
         out_indices=out_indices,
         dynamic_img_size=dynamic_img_size,
-    )
-
-
-@register_model("universal/vit_timm")
-def vit_timm(
-    model_name: str | None = None,
-    checkpoint_path: str | None = None,
-    pretrained: bool = False,
-    dynamic_img_size: bool = True,
-    out_indices: int | Tuple[int, ...] | None = None,
-) -> nn.Module:
-    """Initializes any ViT model from timm with weights from a specified checkpoint.
-
-    This class is mainly provided to facilitate experimentation. E.g. to load
-    a model from a local checkpoint file, without having to manually update
-    the default configuration files.
-
-    Args:
-        model_name: The name of the model to load. If not specified, will
-            load from the environment variable `TIMM_MODEL_NAME`.
-        checkpoint_path: The path to the checkpoint file. If not specified,
-            will load from the environment variable `CHECKPOINT_PATH`.
-        pretrained: If set to `True`, load pretrained ImageNet-1k weights.
-        dynamic_img_size: Support different input image sizes by allowing to change
-            the grid size (interpolate abs and/or ROPE pos) in the forward pass.
-        out_indices: Weather and which multi-level patch embeddings to return.
-
-    Returns:
-        The VIT model instance.
-    """
-    model_name = model_name or os.getenv("TIMM_MODEL_NAME")
-    checkpoint_path = checkpoint_path or os.getenv("CHECKPOINT_PATH")
-    if not model_name:
-        raise ValueError("No model_name is set.")
-    if checkpoint_path and not os.path.exists(checkpoint_path):
-        raise FileNotFoundError(f"Checkpoint file {checkpoint_path} does not exist.")
-
-    logger.info(f"Loading timm model {model_name} from checkpoint {checkpoint_path}")
-    return wrappers.TimmModel(
-        model_name=model_name,
-        checkpoint_path=checkpoint_path or "",
-        pretrained=pretrained,
-        out_indices=out_indices,
-        model_kwargs={
-            "dynamic_img_size": dynamic_img_size,
-        },
     )


### PR DESCRIPTION
Closes #602

Example Usage:


This uses the `wrappers.TimmModel` backbone from the default config file:
```
eva predict_fit --config configs/vision/pathology/offline/segmentation/consep.yaml
```

Use a model from eva's registry:

```
MODEL_NAME=universal/vit_small_patch16_224_imagenet \
OUT_INDICES=1 \
eva predict_fit --config configs/vision/pathology/offline/segmentation/consep.yaml --config configs/vision/backbones/from_registry.yaml
```

(the `backbone:` key in `consep.yaml` is overwritten by the backbone listed in `from_registry.yaml`)