### PR TITLE
Bugfix for monusac worker issue

### DIFF
--- a/src/eva/vision/data/datasets/segmentation/monusac.py
+++ b/src/eva/vision/data/datasets/segmentation/monusac.py
@@ -99,9 +99,6 @@ class MoNuSAC(base.ImageSegmentation):
     def prepare_data(self) -> None:
         if self._download:
             self._download_dataset()
-
-    @override
-    def configure(self) -> None:
         if self._export_masks:
             self._export_semantic_label_masks()
 


### PR DESCRIPTION
When running `predict_fit` using monusac on A100 gpu the following error occurs:
`RuntimeError: DataLoader worker (pid(s) 3463, 3465) exited unexpectedly`

Interestingly, that doesn't happen locally (M1) and neither using K80 GPUs.