### PR TITLE
Set multiprocessing start method to `spawn` for `EmbeddingsDataset`

### DIFF
--- a/src/eva/core/data/datasets/embeddings.py
+++ b/src/eva/core/data/datasets/embeddings.py
@@ -66,7 +66,7 @@ class EmbeddingsDataset(base.Dataset, Generic[TargetType]):
 
         self._data: pd.DataFrame
 
-        multiprocessing.set_start_method("spawn", force=True)
+        self._set_multiprocessing_start_method()
 
     def filename(self, index: int) -> str:
         """Returns the filename of the `index`'th data sample.
@@ -156,3 +156,12 @@ class EmbeddingsDataset(base.Dataset, Generic[TargetType]):
             target = self._target_transforms(target)
 
         return embeddings, target
+
+    def _set_multiprocessing_start_method(self):
+        """Sets the multiprocessing start method to spawn.
+
+        If the start method is not set expliclitly, the torch data loaders will
+        use the OS default method, which for some unix systems is `fork` and
+        can lead to runtime issues such as deadlocks in this context.
+        """
+        multiprocessing.set_start_method("spawn", force=True)

--- a/src/eva/core/data/datasets/embeddings.py
+++ b/src/eva/core/data/datasets/embeddings.py
@@ -1,6 +1,7 @@
 """Base dataset class for Embeddings."""
 
 import abc
+import multiprocessing
 import os
 from typing import Callable, Dict, Generic, Literal, Tuple, TypeVar
 
@@ -64,6 +65,8 @@ class EmbeddingsDataset(base.Dataset, Generic[TargetType]):
         self._target_transforms = target_transforms
 
         self._data: pd.DataFrame
+
+        multiprocessing.set_start_method("spawn", force=True)
 
     def filename(self, index: int) -> str:
         """Returns the filename of the `index`'th data sample.

--- a/src/eva/core/data/datasets/embeddings.py
+++ b/src/eva/core/data/datasets/embeddings.py
@@ -160,7 +160,7 @@ class EmbeddingsDataset(base.Dataset, Generic[TargetType]):
     def _set_multiprocessing_start_method(self):
         """Sets the multiprocessing start method to spawn.
 
-        If the start method is not set expliclitly, the torch data loaders will
+        If the start method is not set explicitly, the torch data loaders will
         use the OS default method, which for some unix systems is `fork` and
         can lead to runtime issues such as deadlocks in this context.
         """


### PR DESCRIPTION
Closes #620

On local machine (macOS) it was working because there the default start method is set to `spawn`, while on the linux machine where the error occured default used by `torch.DataLoader` was `fork` (If you don't specify `multiprocessing_context` expliclitly when initializing a `DataLoader` it will use the OS default).
Using `fork` can be unsafe and lead to issues as deadlocks (see [context](https://stackoverflow.com/a/66113051)).