### PR TITLE
Set available auto download to `False` for `camelyon16`

### DIFF
--- a/src/eva/vision/data/datasets/classification/camelyon16.py
+++ b/src/eva/vision/data/datasets/classification/camelyon16.py
@@ -161,7 +161,7 @@ class Camelyon16(wsi.MultiWsiDataset, base.ImageClassification):
 
     @override
     def prepare_data(self) -> None:
-        _validators.check_dataset_exists(self._root, True)
+        _validators.check_dataset_exists(self._root, False)
 
         expected_directories = ["training/normal", "training/tumor", "testing/images"]
         for resource in expected_directories:


### PR DESCRIPTION
Auto download is not available for `camelyon16`, but currently `check_dataset_exists` prints a message recommending setting the `DOWNLOAD_DATA` env variable.