### PR TITLE
Add `WandbLogger`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,9 @@ cython_debug/
 /lightning_logs/
 /logs/
 
+# wandb
+/wandb/
+
 # ignore local data
 /data/
 

--- a/src/eva/core/loggers/experimental_loggers.py
+++ b/src/eva/core/loggers/experimental_loggers.py
@@ -2,7 +2,7 @@
 
 from typing import Union
 
-from lightning.pytorch.loggers import CSVLogger, TensorBoardLogger
+from lightning.pytorch.loggers import CSVLogger, TensorBoardLogger, WandbLogger
 
 """Supported loggers."""
-ExperimentalLoggers = Union[CSVLogger, TensorBoardLogger]
+ExperimentalLoggers = Union[CSVLogger, TensorBoardLogger, WandbLogger]

--- a/src/eva/core/loggers/log/image.py
+++ b/src/eva/core/loggers/log/image.py
@@ -57,3 +57,15 @@ def _(
         img_tensor=image,
         global_step=step,
     )
+
+
+@log_image.register
+def _(
+    logger: loggers.WandbLogger,
+    tag: str,
+    image: torch.Tensor,
+    caption: str | None = None,
+    step: int = 0,
+) -> None:
+    """Adds a list of images to a Wandb logger."""
+    logger.log_image(key=tag, images=[image.float()], step=step, caption=[caption])

--- a/src/eva/core/loggers/log/parameters.py
+++ b/src/eva/core/loggers/log/parameters.py
@@ -51,6 +51,16 @@ def _(
     )
 
 
+@log_parameters.register
+def _(
+    logger: loggers_lib.WandbLogger,
+    tag: str,
+    parameters: Dict[str, Any],
+) -> None:
+    """Adds parameters to a Wandb logger."""
+    logger.experiment.config.update(parameters)
+
+
 def _yaml_to_markdown(data: Dict[str, Any]) -> str:
     """Casts yaml data to markdown.
 

--- a/src/eva/core/loggers/loggers.py
+++ b/src/eva/core/loggers/loggers.py
@@ -1,6 +1,6 @@
 """Experimental loggers."""
 
-from lightning.pytorch.loggers import TensorBoardLogger
+from lightning.pytorch.loggers import TensorBoardLogger, WandbLogger
 
-Loggers = TensorBoardLogger
+Loggers = TensorBoardLogger | WandbLogger
 """Supported loggers."""

--- a/src/eva/vision/callbacks/loggers/batch/segmentation.py
+++ b/src/eva/vision/callbacks/loggers/batch/segmentation.py
@@ -6,7 +6,6 @@ import torch
 import torchvision
 from lightning import pytorch as pl
 from lightning.pytorch.utilities.types import STEP_OUTPUT
-from torch.nn import functional
 from typing_extensions import override
 
 from eva.core.loggers import log
@@ -22,7 +21,7 @@ class SemanticSegmentationLogger(base.BatchLogger):
     def __init__(
         self,
         max_samples: int = 10,
-        number_of_images_per_subgrid_row: int = 1,
+        number_of_images_per_subgrid_row: int = 2,
         log_images: bool = True,
         mean: Tuple[float, ...] = (0.0, 0.0, 0.0),
         std: Tuple[float, ...] = (1.0, 1.0, 1.0),
@@ -33,8 +32,8 @@ class SemanticSegmentationLogger(base.BatchLogger):
 
         Args:
             max_samples: The maximum number of images displayed in the grid.
-            number_of_images_per_subgrid_row: Number of images displayed in each
-                row of each sub-grid (that is images, targets and predictions).
+            number_of_images_per_subgrid_row: Number of images displayed in each row
+                of each sub-grid (that is images, targets and predictions).
             log_images: Whether to log the input batch images.
             mean: The mean of the input images to de-normalize from.
             std: The std of the input images to de-normalize from.
@@ -72,19 +71,12 @@ class SemanticSegmentationLogger(base.BatchLogger):
         data, targets, predictions = to_cpu([data, targets, predictions])
         predictions = torch.argmax(predictions, dim=1)
 
-        target_images = list(map(_draw_semantic_mask, targets))
-        prediction_images = list(map(_draw_semantic_mask, predictions))
-        image_groups = [target_images, prediction_images]
-
+        targets = list(map(_draw_semantic_mask, targets))
+        predictions = list(map(_draw_semantic_mask, predictions))
+        image_groups = [targets, predictions]
         if self._log_images:
             images = list(map(self._format_image, data))
-            overlay_targets = [
-                _overlay_mask(image, mask) for image, mask in zip(images, targets, strict=False)
-            ]
-            overlay_predictions = [
-                _overlay_mask(image, mask) for image, mask in zip(images, predictions, strict=False)
-            ]
-            image_groups = [images, overlay_targets, overlay_predictions] + image_groups
+            image_groups = [images] + image_groups
 
         image_grid = _make_grid_from_image_groups(
             image_groups, self._number_of_images_per_subgrid_row
@@ -140,26 +132,6 @@ def _draw_semantic_mask(tensor: torch.Tensor) -> torch.Tensor:
         indices = tensor == class_id
         red[indices], green[indices], blue[indices] = color
     return torch.stack([red, green, blue])
-
-
-def _overlay_mask(image: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
-    """Overlays a segmentation mask onto an image.
-
-    Args:
-        image: A 3D tensor of shape (C, H, W) representing the image.
-        mask: A 2D tensor of shape (H, W) representing the segmentation mask.
-            Each pixel in the mask corresponds to a class label.
-
-    Returns:
-        A tensor of the same shape as the input image (C, H, W) with the
-        segmentation mask overlaid on top. The output image retains the
-        original color channels but with the mask applied, using the colors
-        from the predefined colormap.
-    """
-    binary_masks = functional.one_hot(mask).permute(2, 0, 1).to(dtype=torch.bool)
-    return torchvision.utils.draw_segmentation_masks(
-        image, binary_masks[1:], alpha=0.65, colors=colormap.COLORS[1:]  # type: ignore
-    )
 
 
 def _make_grid_from_image_groups(


### PR DESCRIPTION
Closes #627

Example usage:

```yaml
    logger:
      - class_path: lightning.pytorch.loggers.WandbLogger
        init_args:
          project: ${oc.env:WANDB_PROJECT, eva}
          name: ${oc.env:WANDB_RUN_NAME, ""}
```