### PR TITLE
Refactoring of forward method in model wrapper classes

### DIFF
--- a/src/eva/core/models/wrappers/base.py
+++ b/src/eva/core/models/wrappers/base.py
@@ -22,6 +22,8 @@ class BaseModel(nn.Module):
 
         self._output_transforms = tensor_transforms
 
+        self._model: Callable[..., torch.Tensor] | nn.Module
+
     @override
     def forward(self, tensor: torch.Tensor) -> torch.Tensor:
         tensor = self.model_forward(tensor)
@@ -32,14 +34,13 @@ class BaseModel(nn.Module):
         """Loads the model."""
         raise NotImplementedError
 
-    @abc.abstractmethod
     def model_forward(self, tensor: torch.Tensor) -> torch.Tensor:
         """Implements the forward pass of the model.
 
         Args:
             tensor: The input tensor to the model.
         """
-        raise NotImplementedError
+        return self._model(tensor)
 
     def _apply_transforms(self, tensor: torch.Tensor) -> torch.Tensor:
         if self._output_transforms is not None:

--- a/src/eva/core/models/wrappers/from_function.py
+++ b/src/eva/core/models/wrappers/from_function.py
@@ -3,7 +3,6 @@
 from typing import Any, Callable, Dict
 
 import jsonargparse
-import torch
 from torch import nn
 from typing_extensions import override
 
@@ -41,16 +40,12 @@ class ModelFromFunction(base.BaseModel):
         self._arguments = arguments
         self._checkpoint_path = checkpoint_path
 
-        self._model = self.load_model()
+        self.load_model()
 
     @override
-    def load_model(self) -> nn.Module:
+    def load_model(self) -> None:
         class_path = jsonargparse.class_from_function(self._path, func_return=nn.Module)
         model = class_path(**self._arguments or {})
         if self._checkpoint_path is not None:
             _utils.load_model_weights(model, self._checkpoint_path)
-        return model
-
-    @override
-    def model_forward(self, tensor: torch.Tensor) -> torch.Tensor:
-        return self._model(tensor)
+        self._model = model

--- a/src/eva/core/models/wrappers/huggingface.py
+++ b/src/eva/core/models/wrappers/huggingface.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Callable, Dict
 
-import torch
 import transformers
 from typing_extensions import override
 
@@ -33,14 +32,10 @@ class HuggingFaceModel(base.BaseModel):
         self._model_name_or_path = model_name_or_path
         self._model_kwargs = model_kwargs or {}
 
-        self._model = self.load_model()
+        self.load_model()
 
     @override
-    def load_model(self) -> Any:
-        return transformers.AutoModel.from_pretrained(
+    def load_model(self) -> None:
+        self._model = transformers.AutoModel.from_pretrained(
             self._model_name_or_path, **self._model_kwargs
         )
-
-    @override
-    def model_forward(self, tensor: torch.Tensor) -> torch.Tensor:
-        return self._model(tensor)

--- a/src/eva/core/models/wrappers/onnx.py
+++ b/src/eva/core/models/wrappers/onnx.py
@@ -29,19 +29,22 @@ class ONNXModel(base.BaseModel):
 
         self._path = path
         self._device = device
-        self._model = self.load_model()
+
+        self.load_model()
 
     @override
     def load_model(self) -> Any:
         if self._device == "cuda" and not torch.cuda.is_available():
             raise ValueError("Device is set to 'cuda', but CUDA is not available.")
         provider = "CUDAExecutionProvider" if self._device == "cuda" else "CPUExecutionProvider"
-        return ort.InferenceSession(self._path, providers=[provider])
+        self._model = ort.InferenceSession(self._path, providers=[provider])  # type: ignore
 
     @override
     def model_forward(self, tensor: torch.Tensor) -> torch.Tensor:
         # TODO: Use IO binding to avoid copying the tensor to CPU.
         # https://onnxruntime.ai/docs/api/python/api_summary.html#data-on-device
+        if not isinstance(self._model, ort.InferenceSession):
+            raise ValueError("Model is not loaded.")
         inputs = {self._model.get_inputs()[0].name: tensor.detach().cpu().numpy()}
         outputs = self._model.run(None, inputs)[0]
         return torch.from_numpy(outputs).float().to(tensor.device)

--- a/src/eva/vision/models/wrappers/from_registry.py
+++ b/src/eva/vision/models/wrappers/from_registry.py
@@ -1,9 +1,7 @@
 """Vision backbone helper class."""
 
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict
 
-import torch
-from torch import nn
 from typing_extensions import override
 
 from eva.core.models import wrappers
@@ -40,8 +38,6 @@ class ModelFromRegistry(wrappers.BaseModel):
         self._model_kwargs = model_kwargs or {}
         self._model_extra_kwargs = model_extra_kwargs or {}
 
-        self._model: nn.Module
-
         self.load_model()
 
     @override
@@ -50,7 +46,3 @@ class ModelFromRegistry(wrappers.BaseModel):
             self._model_name, self._model_kwargs | self._model_extra_kwargs
         )
         ModelFromRegistry.__name__ = self._model_name
-
-    @override
-    def model_forward(self, tensor: torch.Tensor) -> torch.Tensor | List[torch.Tensor]:
-        return self._model(tensor)

--- a/src/eva/vision/models/wrappers/from_timm.py
+++ b/src/eva/vision/models/wrappers/from_timm.py
@@ -1,11 +1,9 @@
 """Model wrapper for timm models."""
 
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, Tuple
 from urllib import parse
 
 import timm
-import torch
-from torch import nn
 from typing_extensions import override
 
 from eva.core.models import wrappers
@@ -47,14 +45,12 @@ class TimmModel(wrappers.BaseModel):
         self._out_indices = out_indices
         self._model_kwargs = model_kwargs or {}
 
-        self._feature_extractor: nn.Module
-
         self.load_model()
 
     @override
     def load_model(self) -> None:
         """Builds and loads the timm model as feature extractor."""
-        self._feature_extractor = timm.create_model(
+        self._model = timm.create_model(
             model_name=self._model_name,
             pretrained=True if self._checkpoint_path else self._pretrained,
             pretrained_cfg=self._pretrained_cfg,
@@ -63,10 +59,6 @@ class TimmModel(wrappers.BaseModel):
             **self._model_kwargs,
         )
         TimmModel.__name__ = self._model_name
-
-    @override
-    def model_forward(self, tensor: torch.Tensor) -> torch.Tensor | List[torch.Tensor]:
-        return self._feature_extractor(tensor)
 
     @property
     def _pretrained_cfg(self) -> Dict[str, Any]:


### PR DESCRIPTION
This refactoring ensures that all model wrapper classes derived from `BaseModel` will have a `_model` attribute which stores the instantiated model, and is used by default in the forward pass. (So far, each wrapper did this differently, some called it `_model`, others `_feature_extractor`, etc.) 