### PR TITLE
Fix: Skip register tokens in `ExtractPatchFeatures`

### DIFF
--- a/src/eva/core/models/transforms/extract_patch_features.py
+++ b/src/eva/core/models/transforms/extract_patch_features.py
@@ -37,7 +37,7 @@ class ExtractPatchFeatures:
             height = width = int(math.sqrt(patch_grid))
             if height * width != patch_grid:
                 if self._ignore_remaining_dims:
-                    features = features[:, :, : height * width]
+                    features = features[:, :, -height * width :]
                 else:
                     raise ValueError(f"Patch grid size must be a square number {patch_grid}.")
             patch_embeddings = features.view(batch_size, hidden_size, height, width)


### PR DESCRIPTION

The [hibou](https://github.com/HistAI/hibou) models from [hist.ai](http://hist.ai/) use a vit architecture with 4 additional [register](https://arxiv.org/abs/2309.16588) tokens.

For segmentation tasks, we take the last feature map and reshape it to a 2D patch, so to do so the register tokens need to be skipped. In the current code, we seem to include the register tokens and instead skipping image tokens, which leads to poor performance.

See consep performance before & after this fix:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b8a76b94-b0cd-4a88-b5f8-ecf62f400c37">

