### PR TITLE
Update class indices in `MoNuSAC` to make compatible with generalized dice metric

### DIFF
--- a/configs/vision/pathology/offline/segmentation/monusac.yaml
+++ b/configs/vision/pathology/offline/segmentation/monusac.yaml
@@ -63,7 +63,7 @@ model:
       init_args:
         softmax: true
         batch: true
-        ignore_index: &IGNORE_INDEX 255
+        ignore_index: &IGNORE_INDEX 5
     optimizer:
       class_path: torch.optim.AdamW
       init_args:
@@ -84,17 +84,17 @@ model:
       evaluation:
         - class_path: eva.vision.metrics.defaults.MulticlassSegmentationMetrics
           init_args:
-            num_classes: *NUM_CLASSES
+            num_classes: 6
             ignore_index: *IGNORE_INDEX
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
               class_path: eva.vision.metrics.GeneralizedDiceScore
               init_args:
-                num_classes: *NUM_CLASSES
+                num_classes: 6
                 weight_type: linear
-                per_class: true
                 ignore_index: *IGNORE_INDEX
+                per_class: true
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/pathology/online/segmentation/monusac.yaml
+++ b/configs/vision/pathology/online/segmentation/monusac.yaml
@@ -54,7 +54,7 @@ model:
       init_args:
         softmax: true
         batch: true
-        ignore_index: &IGNORE_INDEX 255
+        ignore_index: &IGNORE_INDEX 5
     lr_multiplier_encoder: 0.0
     optimizer:
       class_path: torch.optim.AdamW
@@ -76,14 +76,14 @@ model:
       evaluation:
         - class_path: eva.vision.metrics.defaults.MulticlassSegmentationMetrics
           init_args:
-            num_classes: *NUM_CLASSES
+            num_classes: 6
             ignore_index: *IGNORE_INDEX
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
               class_path: eva.vision.metrics.GeneralizedDiceScore
               init_args:
-                num_classes: *NUM_CLASSES
+                num_classes: 6
                 weight_type: linear
                 ignore_index: *IGNORE_INDEX
                 per_class: true

--- a/src/eva/vision/data/datasets/segmentation/monusac.py
+++ b/src/eva/vision/data/datasets/segmentation/monusac.py
@@ -84,7 +84,7 @@ class MoNuSAC(base.ImageSegmentation):
     @property
     @override
     def classes(self) -> List[str]:
-        return ["Epithelial", "Lymphocyte", "Neutrophil", "Macrophage"]
+        return ["Background", "Epithelial", "Lymphocyte", "Neutrophil", "Macrophage", "Ambiguous"]
 
     @functools.cached_property
     @override
@@ -107,8 +107,8 @@ class MoNuSAC(base.ImageSegmentation):
         _validators.check_dataset_integrity(
             self,
             length=self._expected_dataset_lengths.get(self._split, 0),
-            n_classes=4,
-            first_and_last_labels=("Epithelial", "Macrophage"),
+            n_classes=6,
+            first_and_last_labels=("Background", "Ambiguous"),
         )
 
     @override
@@ -199,9 +199,9 @@ class MoNuSAC(base.ImageSegmentation):
         semantic_labels = np.zeros((height, width), "uint8")  # type: ignore[reportCallIssue]
         for level in range(len(root)):
             label = [item.attrib["Name"] for item in root[level][0]][0]
-            class_id = self.class_to_idx.get(label, 254) + 1
+            class_id = self.class_to_idx.get(label, self.class_to_idx["Ambiguous"])
             # for the test dataset an additional class 'Ambiguous' was added for
-            # difficult regions with fuzzy boundaries - we return it as 255
+            # difficult regions with fuzzy boundaries
             regions = [item for child in root[level] for item in child if item.tag == "Region"]
             for region in regions:
                 vertices = np.array(


### PR DESCRIPTION
Monusac evaluation is not compatible with current metrics implementation:  

```
File "eva-worktrees/eva/src/eva/vision/metrics/segmentation/generalized_dice.py", line 56, in update
    target = _utils.index_to_one_hot(target, num_classes=self.orig_num_classes)
  File "eva-worktrees/eva/src/eva/vision/metrics/segmentation/_utils.py", line 48, in index_to_one_hot
    tensor = torch.nn.functional.one_hot(tensor.long(), num_classes=num_classes).movedim(-1, 1)
RuntimeError: Class values must be smaller than num_classes.
```

The issue was that the `ambigous` class was mapped to a `255`, which is problematic when converting the target tensor to one-hot format.