### PR TITLE
Add `N_DATA_WORKERS` env variable to make dataloader `num_workers` configurable

### DIFF
--- a/configs/vision/pathology/offline/classification/bach.yaml
+++ b/configs/vision/pathology/offline/classification/bach.yaml
@@ -107,7 +107,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 256}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/offline/classification/bach.yaml
+++ b/configs/vision/pathology/offline/classification/bach.yaml
@@ -107,8 +107,11 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 256}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/classification/camelyon16.yaml
+++ b/configs/vision/pathology/offline/classification/camelyon16.yaml
@@ -125,7 +125,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 32}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/offline/classification/camelyon16.yaml
+++ b/configs/vision/pathology/offline/classification/camelyon16.yaml
@@ -125,10 +125,14 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 32}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/classification/camelyon16_small.yaml
+++ b/configs/vision/pathology/offline/classification/camelyon16_small.yaml
@@ -125,7 +125,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 32}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/offline/classification/camelyon16_small.yaml
+++ b/configs/vision/pathology/offline/classification/camelyon16_small.yaml
@@ -125,10 +125,14 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 32}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/classification/crc.yaml
+++ b/configs/vision/pathology/offline/classification/crc.yaml
@@ -105,8 +105,11 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 4096}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/classification/crc.yaml
+++ b/configs/vision/pathology/offline/classification/crc.yaml
@@ -105,7 +105,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 4096}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/offline/classification/mhist.yaml
+++ b/configs/vision/pathology/offline/classification/mhist.yaml
@@ -104,7 +104,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 256}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/offline/classification/mhist.yaml
+++ b/configs/vision/pathology/offline/classification/mhist.yaml
@@ -104,8 +104,11 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 256}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/classification/panda.yaml
+++ b/configs/vision/pathology/offline/classification/panda.yaml
@@ -124,7 +124,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 32}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/offline/classification/panda.yaml
+++ b/configs/vision/pathology/offline/classification/panda.yaml
@@ -124,10 +124,14 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 32}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/classification/panda_small.yaml
+++ b/configs/vision/pathology/offline/classification/panda_small.yaml
@@ -124,7 +124,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 32}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/offline/classification/panda_small.yaml
+++ b/configs/vision/pathology/offline/classification/panda_small.yaml
@@ -124,10 +124,14 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 32}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/classification/patch_camelyon.yaml
+++ b/configs/vision/pathology/offline/classification/patch_camelyon.yaml
@@ -119,7 +119,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 4096}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/offline/classification/patch_camelyon.yaml
+++ b/configs/vision/pathology/offline/classification/patch_camelyon.yaml
@@ -119,10 +119,14 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 4096}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/segmentation/bcss.yaml
+++ b/configs/vision/pathology/offline/segmentation/bcss.yaml
@@ -137,10 +137,14 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/segmentation/bcss.yaml
+++ b/configs/vision/pathology/offline/segmentation/bcss.yaml
@@ -137,7 +137,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/offline/segmentation/consep.yaml
+++ b/configs/vision/pathology/offline/segmentation/consep.yaml
@@ -125,8 +125,11 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/segmentation/consep.yaml
+++ b/configs/vision/pathology/offline/segmentation/consep.yaml
@@ -125,7 +125,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/offline/segmentation/monusac.yaml
+++ b/configs/vision/pathology/offline/segmentation/monusac.yaml
@@ -133,7 +133,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/offline/segmentation/monusac.yaml
+++ b/configs/vision/pathology/offline/segmentation/monusac.yaml
@@ -133,8 +133,11 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/pathology/offline/segmentation/total_segmentator_2d.yaml
@@ -137,10 +137,14 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/offline/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/pathology/offline/segmentation/total_segmentator_2d.yaml
@@ -137,7 +137,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/online/classification/bach.yaml
+++ b/configs/vision/pathology/online/classification/bach.yaml
@@ -89,6 +89,8 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 256}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/online/classification/bach.yaml
+++ b/configs/vision/pathology/online/classification/bach.yaml
@@ -89,7 +89,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 256}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/online/classification/crc.yaml
+++ b/configs/vision/pathology/online/classification/crc.yaml
@@ -87,6 +87,8 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 4096}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/online/classification/crc.yaml
+++ b/configs/vision/pathology/online/classification/crc.yaml
@@ -87,7 +87,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 4096}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/online/classification/mhist.yaml
+++ b/configs/vision/pathology/online/classification/mhist.yaml
@@ -82,6 +82,8 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 256}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/online/classification/mhist.yaml
+++ b/configs/vision/pathology/online/classification/mhist.yaml
@@ -82,7 +82,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 256}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/online/classification/patch_camelyon.yaml
+++ b/configs/vision/pathology/online/classification/patch_camelyon.yaml
@@ -92,7 +92,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 4096}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/online/classification/patch_camelyon.yaml
+++ b/configs/vision/pathology/online/classification/patch_camelyon.yaml
@@ -92,8 +92,11 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 4096}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/online/segmentation/bcss.yaml
+++ b/configs/vision/pathology/online/segmentation/bcss.yaml
@@ -117,7 +117,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/online/segmentation/bcss.yaml
+++ b/configs/vision/pathology/online/segmentation/bcss.yaml
@@ -117,8 +117,11 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/online/segmentation/consep.yaml
+++ b/configs/vision/pathology/online/segmentation/consep.yaml
@@ -108,7 +108,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/online/segmentation/consep.yaml
+++ b/configs/vision/pathology/online/segmentation/consep.yaml
@@ -108,6 +108,8 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/online/segmentation/monusac.yaml
+++ b/configs/vision/pathology/online/segmentation/monusac.yaml
@@ -130,7 +130,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/online/segmentation/monusac.yaml
+++ b/configs/vision/pathology/online/segmentation/monusac.yaml
@@ -130,6 +130,8 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/online/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/pathology/online/segmentation/total_segmentator_2d.yaml
@@ -115,7 +115,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/pathology/online/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/pathology/online/segmentation/total_segmentator_2d.yaml
@@ -115,8 +115,11 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/radiology/offline/segmentation/lits.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits.yaml
@@ -132,10 +132,14 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/radiology/offline/segmentation/lits.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits.yaml
@@ -132,7 +132,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
@@ -132,10 +132,14 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
       predict:
         batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
@@ -132,7 +132,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/radiology/online/segmentation/lits.yaml
+++ b/configs/vision/radiology/online/segmentation/lits.yaml
@@ -111,9 +111,11 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
-        shuffle: true
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/radiology/online/segmentation/lits.yaml
+++ b/configs/vision/radiology/online/segmentation/lits.yaml
@@ -111,7 +111,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/configs/vision/radiology/online/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/online/segmentation/lits_balanced.yaml
@@ -111,9 +111,11 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE
-        shuffle: true
+        num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS

--- a/configs/vision/radiology/online/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/online/segmentation/lits_balanced.yaml
@@ -111,7 +111,7 @@ data:
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
-        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 8}
+        num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
         shuffle: true
       val:
         batch_size: *BATCH_SIZE

--- a/docs/user-guide/getting-started/how_to_use.md
+++ b/docs/user-guide/getting-started/how_to_use.md
@@ -59,3 +59,4 @@ To customize runs, without the need of creating custom config-files, you can ove
 | `MONITOR_METRIC_MODE`   | `str`   | "min" or "max", depending on the `MONITOR_METRIC` used |
 | `REPO_OR_DIR`           | `str`   | GitHub repo with format containing model implementation, e.g. "facebookresearch/dino:main" |
 | `TQDM_REFRESH_RATE`     | `str`   | Determines at which rate (in number of batches) the progress bars get updated. Set it to 0 to disable the progress bar. |
+| `N_DATA_WORKERS`     | `str`   | How many subprocesses to use for the torch dataloaders. |

--- a/docs/user-guide/getting-started/how_to_use.md
+++ b/docs/user-guide/getting-started/how_to_use.md
@@ -59,4 +59,4 @@ To customize runs, without the need of creating custom config-files, you can ove
 | `MONITOR_METRIC_MODE`   | `str`   | "min" or "max", depending on the `MONITOR_METRIC` used |
 | `REPO_OR_DIR`           | `str`   | GitHub repo with format containing model implementation, e.g. "facebookresearch/dino:main" |
 | `TQDM_REFRESH_RATE`     | `str`   | Determines at which rate (in number of batches) the progress bars get updated. Set it to 0 to disable the progress bar. |
-| `N_DATA_WORKERS`     | `str`   | How many subprocesses to use for the torch dataloaders. |
+| `N_DATA_WORKERS`     | `str`   | How many subprocesses to use for the torch dataloaders. Set to `null` to use the number of cpu cores. |

--- a/src/eva/core/data/dataloaders/dataloader.py
+++ b/src/eva/core/data/dataloaders/dataloader.py
@@ -38,12 +38,6 @@ class DataLoader:
     Mutually exclusive with `batch_size`, `shuffle`, `sampler` and `drop_last`.
     """
 
-    num_workers: int = multiprocessing.cpu_count()
-    """How many workers to use for loading the data.
-
-    By default, it will use the number of CPUs available.
-    """
-
     collate_fn: Callable | None = None
     """The batching process."""
 
@@ -58,6 +52,16 @@ class DataLoader:
 
     prefetch_factor: int | None = 2
     """Number of batches loaded in advance by each worker."""
+
+    num_workers: int | None = dataclasses.field(default=None)
+    """How many workers to use for loading the data.
+
+    By default, it will use the number of CPUs available.
+    """
+
+    def __post_init__(self):
+        if self.num_workers is None:
+            self.num_workers = multiprocessing.cpu_count()
 
     def __call__(self, dataset: datasets.TorchDataset) -> dataloader.DataLoader:
         """Returns the dataloader on the provided dataset.

--- a/src/eva/core/data/dataloaders/dataloader.py
+++ b/src/eva/core/data/dataloaders/dataloader.py
@@ -38,6 +38,12 @@ class DataLoader:
     Mutually exclusive with `batch_size`, `shuffle`, `sampler` and `drop_last`.
     """
 
+    num_workers: int | None = None
+    """How many workers to use for loading the data.
+
+    By default, it will use the number of CPUs available.
+    """
+
     collate_fn: Callable | None = None
     """The batching process."""
 
@@ -53,16 +59,6 @@ class DataLoader:
     prefetch_factor: int | None = 2
     """Number of batches loaded in advance by each worker."""
 
-    num_workers: int | None = dataclasses.field(default=None)
-    """How many workers to use for loading the data.
-
-    By default, it will use the number of CPUs available.
-    """
-
-    def __post_init__(self):
-        if self.num_workers is None:
-            self.num_workers = multiprocessing.cpu_count()
-
     def __call__(self, dataset: datasets.TorchDataset) -> dataloader.DataLoader:
         """Returns the dataloader on the provided dataset.
 
@@ -75,7 +71,7 @@ class DataLoader:
             shuffle=self.shuffle,
             sampler=self.sampler,
             batch_sampler=self.batch_sampler,
-            num_workers=self.num_workers,
+            num_workers=self.num_workers or multiprocessing.cpu_count(),
             collate_fn=self.collate_fn,
             pin_memory=self.pin_memory,
             drop_last=self.drop_last,

--- a/src/eva/vision/data/datasets/segmentation/lits.py
+++ b/src/eva/vision/data/datasets/segmentation/lits.py
@@ -96,9 +96,10 @@ class LiTS(base.ImageSegmentation):
     @override
     def validate(self) -> None:
         for i in range(len(self._volume_files)):
-            if not os.path.exists(self._segmentation_file(i)):
+            seg_path = self._segmentation_file(i)
+            if not os.path.exists(seg_path):
                 raise FileNotFoundError(
-                    f"Segmentation file not found for volume {self._volume_files[i]}."
+                    f"Segmentation file {seg_path} not found for volume {self._volume_files[i]}."
                 )
 
         _validators.check_dataset_integrity(


### PR DESCRIPTION
Closes #679

Using a new default of 4 workers, as for most datapipelines speed doesn't seem to improve by increasing the worker count further.