### PR TITLE
Make metrics device configurable through `METRICS_DEVICE` env variable

### DIFF
--- a/docs/user-guide/getting-started/how_to_use.md
+++ b/docs/user-guide/getting-started/how_to_use.md
@@ -59,3 +59,4 @@ To customize runs, without the need of creating custom config-files, you can ove
 | `MONITOR_METRIC_MODE`   | `str`   | "min" or "max", depending on the `MONITOR_METRIC` used |
 | `REPO_OR_DIR`           | `str`   | GitHub repo with format containing model implementation, e.g. "facebookresearch/dino:main" |
 | `TQDM_REFRESH_RATE`     | `str`   | Determines at which rate (in number of batches) the progress bars get updated. Set it to 0 to disable the progress bar. |
+| `METRICS_DEVICE`        | `str`   | Specifies the device on which to compute the metrics. If not set, will use the same device as used for training. |

--- a/src/eva/core/models/modules/module.py
+++ b/src/eva/core/models/modules/module.py
@@ -1,10 +1,10 @@
 """Base model module."""
 
+import os
 from typing import Any, Mapping
 
 import lightning.pytorch as pl
 import torch
-from lightning.pytorch.strategies.single_device import SingleDeviceStrategy
 from lightning.pytorch.utilities import memory
 from lightning.pytorch.utilities.types import STEP_OUTPUT
 from typing_extensions import override
@@ -49,14 +49,9 @@ class ModelModule(pl.LightningModule):
 
     @property
     def metrics_device(self) -> torch.device:
-        """Returns the device by which the metrics should be calculated.
-
-        We allocate the metrics to CPU when operating on single device, as
-        it is much faster, but to GPU when employing multiple ones, as DDP
-        strategy requires the metrics to be allocated to the module's GPU.
-        """
-        move_to_cpu = isinstance(self.trainer.strategy, SingleDeviceStrategy)
-        return torch.device("cpu") if move_to_cpu else self.device
+        """Returns the device by which the metrics should be calculated."""
+        device = os.getenv("METRICS_DEVICE", None)
+        return self.device if device is None else torch.device(device)
 
     @override
     def on_fit_start(self) -> None:


### PR DESCRIPTION
Closes #677

Segmentation metrics calculation runs much faster on GPU - tested on `mps` and A100 gpu - Therefore the new default is to use the same device as for training for the metrics calculation.