### PR TITLE
Set default metrics device to cpu

### DIFF
--- a/src/eva/core/models/modules/module.py
+++ b/src/eva/core/models/modules/module.py
@@ -50,7 +50,7 @@ class ModelModule(pl.LightningModule):
     @property
     def metrics_device(self) -> torch.device:
         """Returns the device by which the metrics should be calculated."""
-        device = os.getenv("METRICS_DEVICE", None)
+        device = os.getenv("METRICS_DEVICE", "cpu")
         return self.device if device is None else torch.device(device)
 
     @override


### PR DESCRIPTION
For some reason, calculating the metrics on gpu gives random & invalid results. Setting the default back to `cpu` until we figure out why.