### PR TITLE
Replace `GeneralizedDiceScore` by `DiceScore` & fix class-wise metrics

### DIFF
--- a/configs/vision/pathology/offline/segmentation/bcss.yaml
+++ b/configs/vision/pathology/offline/segmentation/bcss.yaml
@@ -20,7 +20,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/pathology/offline/segmentation/bcss.yaml
+++ b/configs/vision/pathology/offline/segmentation/bcss.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/pathology/offline/segmentation/bcss.yaml
+++ b/configs/vision/pathology/offline/segmentation/bcss.yaml
@@ -20,7 +20,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -86,11 +86,17 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: *NUM_CLASSES
-                weight_type: linear
-                per_class: true
+                average: none
+            labels:
+              - outside_roi
+              - tumor
+              - stroma
+              - inflammatory
+              - necrosis
+              - other
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/pathology/offline/segmentation/bcss.yaml
+++ b/configs/vision/pathology/offline/segmentation/bcss.yaml
@@ -86,10 +86,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: *NUM_CLASSES
-                average: none
+                reduction: none
             labels:
               - outside_roi
               - tumor

--- a/configs/vision/pathology/offline/segmentation/consep.yaml
+++ b/configs/vision/pathology/offline/segmentation/consep.yaml
@@ -20,7 +20,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -86,11 +86,16 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: *NUM_CLASSES
-                weight_type: linear
-                per_class: true
+                average: none
+            labels:
+              - background
+              - other
+              - inflammatory
+              - epithelial
+              - spindle-shaped
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/pathology/offline/segmentation/consep.yaml
+++ b/configs/vision/pathology/offline/segmentation/consep.yaml
@@ -86,10 +86,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: *NUM_CLASSES
-                average: none
+                reduction: none
             labels:
               - background
               - other

--- a/configs/vision/pathology/offline/segmentation/consep.yaml
+++ b/configs/vision/pathology/offline/segmentation/consep.yaml
@@ -20,7 +20,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/pathology/offline/segmentation/monusac.yaml
+++ b/configs/vision/pathology/offline/segmentation/monusac.yaml
@@ -24,7 +24,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/pathology/offline/segmentation/monusac.yaml
+++ b/configs/vision/pathology/offline/segmentation/monusac.yaml
@@ -89,10 +89,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: 6
-                average: none
+                reduction: none
                 ignore_index: *IGNORE_INDEX
             labels:
               - background

--- a/configs/vision/pathology/offline/segmentation/monusac.yaml
+++ b/configs/vision/pathology/offline/segmentation/monusac.yaml
@@ -23,7 +23,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -89,12 +89,18 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: 6
-                weight_type: linear
+                average: none
                 ignore_index: *IGNORE_INDEX
-                per_class: true
+            labels:
+              - background
+              - epithelial
+              - lymphocyte
+              - neutrophil
+              - macrophage
+              - ambiguous
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/pathology/offline/segmentation/monusac.yaml
+++ b/configs/vision/pathology/offline/segmentation/monusac.yaml
@@ -23,7 +23,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/pathology/online/segmentation/bcss.yaml
+++ b/configs/vision/pathology/online/segmentation/bcss.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -79,11 +79,17 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: *NUM_CLASSES
-                weight_type: linear
-                per_class: true
+                average: none
+            labels:
+              - outside_roi
+              - tumor
+              - stroma
+              - inflammatory
+              - necrosis
+              - other
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/pathology/online/segmentation/bcss.yaml
+++ b/configs/vision/pathology/online/segmentation/bcss.yaml
@@ -79,10 +79,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: *NUM_CLASSES
-                average: none
+                reduction: none
             labels:
               - outside_roi
               - tumor

--- a/configs/vision/pathology/online/segmentation/bcss.yaml
+++ b/configs/vision/pathology/online/segmentation/bcss.yaml
@@ -22,7 +22,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/pathology/online/segmentation/bcss.yaml
+++ b/configs/vision/pathology/online/segmentation/bcss.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/pathology/online/segmentation/consep.yaml
+++ b/configs/vision/pathology/online/segmentation/consep.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -79,11 +79,16 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: *NUM_CLASSES
-                weight_type: linear
-                per_class: true
+                average: none
+            labels:
+              - background
+              - other
+              - inflammatory
+              - epithelial
+              - spindle-shaped
 data:
   class_path: eva.DataModule
   init_args:
@@ -109,7 +114,7 @@ data:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
         num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
-        shuffle: true
+        shuffle: false
       val:
         batch_size: *BATCH_SIZE
         num_workers: *N_DATA_WORKERS

--- a/configs/vision/pathology/online/segmentation/consep.yaml
+++ b/configs/vision/pathology/online/segmentation/consep.yaml
@@ -22,7 +22,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/pathology/online/segmentation/consep.yaml
+++ b/configs/vision/pathology/online/segmentation/consep.yaml
@@ -79,10 +79,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: *NUM_CLASSES
-                average: none
+                reduction: none
             labels:
               - background
               - other

--- a/configs/vision/pathology/online/segmentation/consep.yaml
+++ b/configs/vision/pathology/online/segmentation/consep.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/pathology/online/segmentation/monusac.yaml
+++ b/configs/vision/pathology/online/segmentation/monusac.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -81,12 +81,18 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: 6
-                weight_type: linear
+                average: none
                 ignore_index: *IGNORE_INDEX
-                per_class: true
+            labels:
+              - background
+              - epithelial
+              - lymphocyte
+              - neutrophil
+              - macrophage
+              - ambiguous
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/pathology/online/segmentation/monusac.yaml
+++ b/configs/vision/pathology/online/segmentation/monusac.yaml
@@ -81,10 +81,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: 6
-                average: none
+                reduction: none
                 ignore_index: *IGNORE_INDEX
             labels:
               - background

--- a/configs/vision/pathology/online/segmentation/monusac.yaml
+++ b/configs/vision/pathology/online/segmentation/monusac.yaml
@@ -22,7 +22,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/pathology/online/segmentation/monusac.yaml
+++ b/configs/vision/pathology/online/segmentation/monusac.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/offline/segmentation/lits.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits.yaml
@@ -19,7 +19,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/offline/segmentation/lits.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits.yaml
@@ -19,7 +19,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -84,11 +84,14 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: *NUM_CLASSES
-                weight_type: linear
-                per_class: true
+                average: none
+            labels:
+              - background
+              - liver
+              - tumor
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/radiology/offline/segmentation/lits.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits.yaml
@@ -84,10 +84,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: *NUM_CLASSES
-                average: none
+                reduction: none
             labels:
               - background
               - liver

--- a/configs/vision/radiology/offline/segmentation/lits.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits.yaml
@@ -19,7 +19,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
@@ -19,7 +19,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
@@ -19,7 +19,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -84,11 +84,14 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: *NUM_CLASSES
-                weight_type: linear
-                per_class: true
+                average: none
+            labels:
+              - background
+              - liver
+              - tumor
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
@@ -84,10 +84,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: *NUM_CLASSES
-                average: none
+                reduction: none
             labels:
               - background
               - liver

--- a/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/offline/segmentation/lits_balanced.yaml
@@ -20,7 +20,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/offline/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/radiology/offline/segmentation/total_segmentator_2d.yaml
@@ -20,7 +20,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/offline/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/radiology/offline/segmentation/total_segmentator_2d.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/offline/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/radiology/offline/segmentation/total_segmentator_2d.yaml
@@ -20,7 +20,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -28,6 +28,20 @@ trainer:
           patience: 5
           monitor: *MONITOR_METRIC
           mode: *MONITOR_METRIC_MODE
+      - class_path: eva.callbacks.SegmentationEmbeddingsWriter
+        init_args:
+          output_dir: &DATASET_EMBEDDINGS_ROOT ${oc.env:EMBEDDINGS_ROOT, ./data/embeddings}/${oc.env:MODEL_NAME, vit_small_patch16_224_dino}/total_segmentator_2d
+          dataloader_idx_map:
+            0: train
+            1: test
+          overwrite: false
+          backbone:
+            class_path: eva.vision.models.ModelFromRegistry
+            init_args:
+              model_name: ${oc.env:MODEL_NAME, universal/vit_small_patch16_224_dino}
+              model_kwargs:
+                out_indices: ${oc.env:OUT_INDICES, 1}
+              model_extra_kwargs: ${oc.env:MODEL_EXTRA_KWARGS, null}
     logger:
       - class_path: lightning.pytorch.loggers.TensorBoardLogger
         init_args:
@@ -36,13 +50,6 @@ trainer:
 model:
   class_path: eva.vision.models.modules.SemanticSegmentationModule
   init_args:
-    encoder:
-      class_path: eva.vision.models.ModelFromRegistry
-      init_args:
-        model_name: ${oc.env:MODEL_NAME, universal/vit_small_patch16_224_dino}
-        model_kwargs:
-          out_indices: ${oc.env:OUT_INDICES, 1}
-        model_extra_kwargs: ${oc.env:MODEL_EXTRA_KWARGS, null}
     decoder:
       class_path: eva.vision.models.networks.decoders.segmentation.ConvDecoderMS
       init_args:
@@ -78,40 +85,54 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: *NUM_CLASSES
-                weight_type: linear
-                per_class: true
+                average: none
 data:
   class_path: eva.DataModule
   init_args:
     datasets:
       train:
-        class_path: eva.vision.datasets.TotalSegmentator2D
+        class_path: eva.vision.datasets.EmbeddingsSegmentationDataset
         init_args: &DATASET_ARGS
-          root: ${oc.env:DATA_ROOT, ./data/total_segmentator}
+          root: *DATASET_EMBEDDINGS_ROOT
+          manifest_file: manifest.csv
           split: train
-          download: ${oc.env:DOWNLOAD_DATA, false}
-          # Set `download: true` to download the dataset from https://zenodo.org/records/10047292
-          # The TotalSegmentator dataset is distributed under the following license: 
-          # "Creative Commons Attribution 4.0 International"
-          # (see: https://creativecommons.org/licenses/by/4.0/deed.en)
-          transforms:
-            class_path: eva.vision.data.transforms.common.ResizeAndClamp
-            init_args:
-              mean: *NORMALIZE_MEAN
-              std: *NORMALIZE_STD
       val:
-        class_path: eva.vision.datasets.TotalSegmentator2D
+        class_path: eva.vision.datasets.EmbeddingsSegmentationDataset
         init_args:
           <<: *DATASET_ARGS
           split: val
       test:
-        class_path: eva.vision.datasets.TotalSegmentator2D
+        class_path: eva.vision.datasets.EmbeddingsSegmentationDataset
         init_args:
           <<: *DATASET_ARGS
           split: test
+      predict:
+        - class_path: eva.vision.datasets.TotalSegmentator2D
+          init_args: &PREDICT_DATASET_ARGS
+            root: ${oc.env:DATA_ROOT, ./data/total_segmentator}
+            split: train
+            download: ${oc.env:DOWNLOAD_DATA, false}
+            # Set `download: true` to download the dataset from https://zenodo.org/records/10047292
+            # The TotalSegmentator dataset is distributed under the following license: 
+            # "Creative Commons Attribution 4.0 International"
+            # (see: https://creativecommons.org/licenses/by/4.0/deed.en)
+            transforms:
+              class_path: eva.vision.data.transforms.common.ResizeAndCrop
+              init_args:
+                size: ${oc.env:RESIZE_DIM, 224}  
+                mean: *NORMALIZE_MEAN
+                std: *NORMALIZE_STD
+        - class_path: eva.vision.datasets.TotalSegmentator2D
+          init_args:
+            <<: *PREDICT_DATASET_ARGS
+            split: val
+        - class_path: eva.vision.datasets.TotalSegmentator2D
+          init_args:
+            <<: *PREDICT_DATASET_ARGS
+            split: test
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
@@ -122,4 +143,7 @@ data:
         num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
+        num_workers: *N_DATA_WORKERS
+      predict:
+        batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
         num_workers: *N_DATA_WORKERS

--- a/configs/vision/radiology/offline/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/radiology/offline/segmentation/total_segmentator_2d.yaml
@@ -85,10 +85,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: *NUM_CLASSES
-                average: none
+                reduction: none
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/radiology/online/segmentation/lits.yaml
+++ b/configs/vision/radiology/online/segmentation/lits.yaml
@@ -77,10 +77,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: *NUM_CLASSES
-                average: none
+                reduction: none
             labels:
               - background
               - liver

--- a/configs/vision/radiology/online/segmentation/lits.yaml
+++ b/configs/vision/radiology/online/segmentation/lits.yaml
@@ -22,7 +22,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/online/segmentation/lits.yaml
+++ b/configs/vision/radiology/online/segmentation/lits.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/online/segmentation/lits.yaml
+++ b/configs/vision/radiology/online/segmentation/lits.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -77,11 +77,14 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: *NUM_CLASSES
-                weight_type: linear
-                per_class: true
+                average: none
+            labels:
+              - background
+              - liver
+              - tumor
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/radiology/online/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/online/segmentation/lits_balanced.yaml
@@ -77,10 +77,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: *NUM_CLASSES
-                average: none
+                reduction: none
             labels:
               - background
               - liver

--- a/configs/vision/radiology/online/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/online/segmentation/lits_balanced.yaml
@@ -22,7 +22,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/online/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/online/segmentation/lits_balanced.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/online/segmentation/lits_balanced.yaml
+++ b/configs/vision/radiology/online/segmentation/lits_balanced.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -77,11 +77,14 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: *NUM_CLASSES
-                weight_type: linear
-                per_class: true
+                average: none
+            labels:
+              - background
+              - liver
+              - tumor
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/radiology/online/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/radiology/online/segmentation/total_segmentator_2d.yaml
@@ -20,7 +20,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/online/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/radiology/online/segmentation/total_segmentator_2d.yaml
@@ -21,7 +21,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'MonaiDiceScore'}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/MonaiDiceScore'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:

--- a/configs/vision/radiology/online/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/radiology/online/segmentation/total_segmentator_2d.yaml
@@ -78,10 +78,11 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.DiceScore
+              class_path: eva.vision.metrics.MonaiDiceScore
               init_args:
+                include_background: true
                 num_classes: *NUM_CLASSES
-                average: none
+                reduction: none
 data:
   class_path: eva.DataModule
   init_args:

--- a/configs/vision/radiology/online/segmentation/total_segmentator_2d.yaml
+++ b/configs/vision/radiology/online/segmentation/total_segmentator_2d.yaml
@@ -20,7 +20,7 @@ trainer:
           filename: best
           save_last: true
           save_top_k: 1
-          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, val/GeneralizedDiceScore}
+          monitor: &MONITOR_METRIC ${oc.env:MONITOR_METRIC, 'val/DiceScore (micro)'}
           mode: &MONITOR_METRIC_MODE ${oc.env:MONITOR_METRIC_MODE, max}
       - class_path: lightning.pytorch.callbacks.EarlyStopping
         init_args:
@@ -28,20 +28,6 @@ trainer:
           patience: 5
           monitor: *MONITOR_METRIC
           mode: *MONITOR_METRIC_MODE
-      - class_path: eva.callbacks.SegmentationEmbeddingsWriter
-        init_args:
-          output_dir: &DATASET_EMBEDDINGS_ROOT ${oc.env:EMBEDDINGS_ROOT, ./data/embeddings}/${oc.env:MODEL_NAME, vit_small_patch16_224_dino}/total_segmentator_2d
-          dataloader_idx_map:
-            0: train
-            1: test
-          overwrite: false
-          backbone:
-            class_path: eva.vision.models.ModelFromRegistry
-            init_args:
-              model_name: ${oc.env:MODEL_NAME, universal/vit_small_patch16_224_dino}
-              model_kwargs:
-                out_indices: ${oc.env:OUT_INDICES, 1}
-              model_extra_kwargs: ${oc.env:MODEL_EXTRA_KWARGS, null}
     logger:
       - class_path: lightning.pytorch.loggers.TensorBoardLogger
         init_args:
@@ -50,6 +36,13 @@ trainer:
 model:
   class_path: eva.vision.models.modules.SemanticSegmentationModule
   init_args:
+    encoder:
+      class_path: eva.vision.models.ModelFromRegistry
+      init_args:
+        model_name: ${oc.env:MODEL_NAME, universal/vit_small_patch16_224_dino}
+        model_kwargs:
+          out_indices: ${oc.env:OUT_INDICES, 1}
+        model_extra_kwargs: ${oc.env:MODEL_EXTRA_KWARGS, null}
     decoder:
       class_path: eva.vision.models.networks.decoders.segmentation.ConvDecoderMS
       init_args:
@@ -85,55 +78,39 @@ model:
         - class_path: torchmetrics.ClasswiseWrapper
           init_args:
             metric:
-              class_path: eva.vision.metrics.GeneralizedDiceScore
+              class_path: eva.vision.metrics.DiceScore
               init_args:
                 num_classes: *NUM_CLASSES
-                weight_type: linear
-                per_class: true
+                average: none
 data:
   class_path: eva.DataModule
   init_args:
     datasets:
       train:
-        class_path: eva.vision.datasets.EmbeddingsSegmentationDataset
+        class_path: eva.vision.datasets.TotalSegmentator2D
         init_args: &DATASET_ARGS
-          root: *DATASET_EMBEDDINGS_ROOT
-          manifest_file: manifest.csv
+          root: ${oc.env:DATA_ROOT, ./data/total_segmentator}
           split: train
+          download: ${oc.env:DOWNLOAD_DATA, false}
+          # Set `download: true` to download the dataset from https://zenodo.org/records/10047292
+          # The TotalSegmentator dataset is distributed under the following license: 
+          # "Creative Commons Attribution 4.0 International"
+          # (see: https://creativecommons.org/licenses/by/4.0/deed.en)
+          transforms:
+            class_path: eva.vision.data.transforms.common.ResizeAndClamp
+            init_args:
+              mean: *NORMALIZE_MEAN
+              std: *NORMALIZE_STD
       val:
-        class_path: eva.vision.datasets.EmbeddingsSegmentationDataset
+        class_path: eva.vision.datasets.TotalSegmentator2D
         init_args:
           <<: *DATASET_ARGS
           split: val
       test:
-        class_path: eva.vision.datasets.EmbeddingsSegmentationDataset
+        class_path: eva.vision.datasets.TotalSegmentator2D
         init_args:
           <<: *DATASET_ARGS
           split: test
-      predict:
-        - class_path: eva.vision.datasets.TotalSegmentator2D
-          init_args: &PREDICT_DATASET_ARGS
-            root: ${oc.env:DATA_ROOT, ./data/total_segmentator}
-            split: train
-            download: ${oc.env:DOWNLOAD_DATA, false}
-            # Set `download: true` to download the dataset from https://zenodo.org/records/10047292
-            # The TotalSegmentator dataset is distributed under the following license: 
-            # "Creative Commons Attribution 4.0 International"
-            # (see: https://creativecommons.org/licenses/by/4.0/deed.en)
-            transforms:
-              class_path: eva.vision.data.transforms.common.ResizeAndCrop
-              init_args:
-                size: ${oc.env:RESIZE_DIM, 224}  
-                mean: *NORMALIZE_MEAN
-                std: *NORMALIZE_STD
-        - class_path: eva.vision.datasets.TotalSegmentator2D
-          init_args:
-            <<: *PREDICT_DATASET_ARGS
-            split: val
-        - class_path: eva.vision.datasets.TotalSegmentator2D
-          init_args:
-            <<: *PREDICT_DATASET_ARGS
-            split: test
     dataloaders:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
@@ -144,7 +121,4 @@ data:
         num_workers: *N_DATA_WORKERS
       test:
         batch_size: *BATCH_SIZE
-        num_workers: *N_DATA_WORKERS
-      predict:
-        batch_size: &PREDICT_BATCH_SIZE ${oc.env:PREDICT_BATCH_SIZE, 64}
         num_workers: *N_DATA_WORKERS

--- a/docs/datasets/consep.md
+++ b/docs/datasets/consep.md
@@ -2,6 +2,7 @@
 
 CoNSep (Colorectal Nuclear Segmentation and Phenotypes) consists of 41 1000x1000 tiles extracted from 16 WSIs of unique patients. Labels are segmentation masks which indicate if a pixel belongs to one of 7 categories of cell nuclei. In total 24,319 unique nuclei are present.
 
+
 ## Raw data
 
 ### Key stats
@@ -9,7 +10,7 @@ CoNSep (Colorectal Nuclear Segmentation and Phenotypes) consists of 41 1000x1000
 |                       |                                                           |
 |-----------------------|-----------------------------------------------------------|
 | **Modality**          | Vision (WSI patches)                                      |
-| **Task**              | Segmentation - 8 classes (non-"cell nucleus" + 7 categories)|
+| **Task**              | Segmentation - 4 classes *                           |
 | **Data size**         | total: ~800MB                                             |
 | **Image dimension**   | 1000 x 1000 x 3                                           |
 | **Magnification (μm/px)**  | 40x (0.25)                                           |
@@ -17,6 +18,18 @@ CoNSep (Colorectal Nuclear Segmentation and Phenotypes) consists of 41 1000x1000
 | **Number of images**  | 41                                                        |
 | **Splits in use**     | Train and Test                                            |
 
+
+\* The original dataset has 7 classes:
+
+1. Miscellaneous
+2. Inflammatory
+3. Normal epithelium
+4. Malignant/dysplastic	epithelium
+5. Fibroblast
+6. Muscle
+7. Endothelial
+
+As in the original paper [1], we combine classes 3 (normal epithelial) & 4 (malignant/dysplastic epithelial) into the epithelial class and 5 (fibroblast), 6 (muscle) & 7 (endothelial) into the spindle-shaped class.
 
 ### Organization
 
@@ -53,8 +66,7 @@ We work with the splits provided by the data source. Since no "validation" split
 
 | Splits   | Train           | Validation   | 
 |----------|-----------------|--------------|
-| #Samples | 27 (66%) | 14 (34%) | 
-
+| #Samples | 27 (66%)        | 14 (34%)     | 
 
 ## Relevant links
 
@@ -65,3 +77,6 @@ We work with the splits provided by the data source. Since no "validation" split
 ## License
 
 The CoNSeP dataset are held under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+## References
+[1] : [HoVer-Net: Simultaneous Segmentation and Classification of Nuclei in Multi-Tissue Histology Images](https://arxiv.org/abs/1812.06499)

--- a/docs/datasets/monusac.md
+++ b/docs/datasets/monusac.md
@@ -9,7 +9,7 @@ MoNuSAC (Multi-Organ Nuclei Segmentation And Classification Challenge) consists 
 |                       |                                                           |
 |-----------------------|-----------------------------------------------------------|
 | **Modality**          | Vision (WSI patches)                                      |
-| **Task**              | Segmentation - 4 classes                                  |
+| **Task**              | Segmentation - 5 classes *                               |
 | **Data size**         | total: ~600MB                                             |
 | **Image dimension**   | 113x81 - 1398x1956                                        |
 | **Magnification (μm/px)**  | 40x (0.25)                                           |
@@ -17,6 +17,7 @@ MoNuSAC (Multi-Organ Nuclei Segmentation And Classification Challenge) consists 
 | **Number of images**  | 294                                                       |
 | **Splits in use**     | Train and Test                                            |
 
+\* The fith class is "ambiguous" and doesn't contain a specific cell type.
 
 ### Organization
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "all", "dev", "docs", "lint", "test", "typecheck", "vision"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:b8df35bf60e5573e36c31c4ad4f324d7693f16b31cadcd27e48b352ae6c0235b"
+content_hash = "sha256:5b9e7f8ba62696f3e07200365e1c11658c9c9bd24dbffa67f790b30f4ab0ff01"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -2743,20 +2743,20 @@ files = [
 
 [[package]]
 name = "torchmetrics"
-version = "1.4.2"
-requires_python = ">=3.8"
+version = "1.6.0"
+requires_python = ">=3.9"
 summary = "PyTorch native Metrics"
 groups = ["default"]
 dependencies = [
     "lightning-utilities>=0.8.0",
     "numpy>1.20.0",
     "packaging>17.1",
-    "torch>=1.10.0",
+    "torch>=2.0.0",
     "typing-extensions; python_version < \"3.9\"",
 ]
 files = [
-    {file = "torchmetrics-1.4.2-py3-none-any.whl", hash = "sha256:87b9eca51ff6f93985a0f9db509f646cb45425b016f4d2f383d8c28d40dde5b6"},
-    {file = "torchmetrics-1.4.2.tar.gz", hash = "sha256:7a40cbec85e5645090812b87601696b4adf158294ec8c407ae58a71710938b87"},
+    {file = "torchmetrics-1.6.0-py3-none-any.whl", hash = "sha256:a508cdd87766cedaaf55a419812bf9f493aff8fffc02cc19df5a8e2e7ccb942a"},
+    {file = "torchmetrics-1.6.0.tar.gz", hash = "sha256:aebba248708fb90def20cccba6f55bddd134a58de43fb22b0c5ca0f3a89fa984"},
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "all", "dev", "docs", "lint", "test", "typecheck", "vision"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:5b9e7f8ba62696f3e07200365e1c11658c9c9bd24dbffa67f790b30f4ab0ff01"
+content_hash = "sha256:b8df35bf60e5573e36c31c4ad4f324d7693f16b31cadcd27e48b352ae6c0235b"
 
 [[metadata.targets]]
 requires_python = ">=3.10"
@@ -2743,20 +2743,20 @@ files = [
 
 [[package]]
 name = "torchmetrics"
-version = "1.6.0"
-requires_python = ">=3.9"
+version = "1.4.2"
+requires_python = ">=3.8"
 summary = "PyTorch native Metrics"
 groups = ["default"]
 dependencies = [
     "lightning-utilities>=0.8.0",
     "numpy>1.20.0",
     "packaging>17.1",
-    "torch>=2.0.0",
+    "torch>=1.10.0",
     "typing-extensions; python_version < \"3.9\"",
 ]
 files = [
-    {file = "torchmetrics-1.6.0-py3-none-any.whl", hash = "sha256:a508cdd87766cedaaf55a419812bf9f493aff8fffc02cc19df5a8e2e7ccb942a"},
-    {file = "torchmetrics-1.6.0.tar.gz", hash = "sha256:aebba248708fb90def20cccba6f55bddd134a58de43fb22b0c5ca0f3a89fa984"},
+    {file = "torchmetrics-1.4.2-py3-none-any.whl", hash = "sha256:87b9eca51ff6f93985a0f9db509f646cb45425b016f4d2f383d8c28d40dde5b6"},
+    {file = "torchmetrics-1.4.2.tar.gz", hash = "sha256:7a40cbec85e5645090812b87601696b4adf158294ec8c407ae58a71710938b87"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "onnx>=1.16.0",
     "toolz>=0.12.1",
     "rich>=13.7.1",
-    "torchmetrics>=1.4.2",
+    "torchmetrics>=1.6.0",
 ]
 
 [project.urls]

--- a/src/eva/vision/data/datasets/segmentation/consep.py
+++ b/src/eva/vision/data/datasets/segmentation/consep.py
@@ -20,9 +20,12 @@ from eva.vision.utils import io
 class CoNSeP(wsi.MultiWsiDataset, base.ImageSegmentation):
     """Dataset class for CoNSeP semantic segmentation task.
 
-    We combine classes 3 (healthy epithelial) & 4 (dysplastic/malignant epithelial)
+    As in [1], we combine classes 3 (healthy epithelial) & 4 (dysplastic/malignant epithelial)
     into the epithelial class and 5 (fibroblast), 6 (muscle) & 7 (endothelial) into
     the spindle-shaped class.
+
+    [1] Graham, Simon, et al. "Hover-net: Simultaneous segmentation and classification of
+        nuclei in multi-tissue histology images." https://arxiv.org/abs/1802.04712
     """
 
     _expected_dataset_lengths: Dict[str | None, int] = {

--- a/src/eva/vision/data/datasets/segmentation/lits.py
+++ b/src/eva/vision/data/datasets/segmentation/lits.py
@@ -76,7 +76,7 @@ class LiTS(base.ImageSegmentation):
     @property
     @override
     def classes(self) -> List[str]:
-        return ["liver", "tumor"]
+        return ["background", "liver", "tumor"]
 
     @functools.cached_property
     @override

--- a/src/eva/vision/data/datasets/segmentation/lits.py
+++ b/src/eva/vision/data/datasets/segmentation/lits.py
@@ -105,8 +105,8 @@ class LiTS(base.ImageSegmentation):
         _validators.check_dataset_integrity(
             self,
             length=self._expected_dataset_lengths.get(self._split, 0),
-            n_classes=2,
-            first_and_last_labels=("liver", "tumor"),
+            n_classes=3,
+            first_and_last_labels=("background", "tumor"),
         )
 
     @override

--- a/src/eva/vision/metrics/__init__.py
+++ b/src/eva/vision/metrics/__init__.py
@@ -1,11 +1,13 @@
 """Default metric collections API."""
 
 from eva.vision.metrics.defaults.segmentation import MulticlassSegmentationMetrics
+from eva.vision.metrics.segmentation.dice import DiceScore
 from eva.vision.metrics.segmentation.generalized_dice import GeneralizedDiceScore
 from eva.vision.metrics.segmentation.mean_iou import MeanIoU
 
 __all__ = [
-    "MulticlassSegmentationMetrics",
+    "DiceScore",
     "GeneralizedDiceScore",
+    "MulticlassSegmentationMetrics",
     "MeanIoU",
 ]

--- a/src/eva/vision/metrics/__init__.py
+++ b/src/eva/vision/metrics/__init__.py
@@ -4,10 +4,12 @@ from eva.vision.metrics.defaults.segmentation import MulticlassSegmentationMetri
 from eva.vision.metrics.segmentation.dice import DiceScore
 from eva.vision.metrics.segmentation.generalized_dice import GeneralizedDiceScore
 from eva.vision.metrics.segmentation.mean_iou import MeanIoU
+from eva.vision.metrics.segmentation.monai_dice import MonaiDiceScore
 
 __all__ = [
     "DiceScore",
     "GeneralizedDiceScore",
-    "MulticlassSegmentationMetrics",
     "MeanIoU",
+    "MonaiDiceScore",
+    "MulticlassSegmentationMetrics",
 ]

--- a/src/eva/vision/metrics/defaults/segmentation/multiclass.py
+++ b/src/eva/vision/metrics/defaults/segmentation/multiclass.py
@@ -1,7 +1,7 @@
 """Default metric collection for multiclass semantic segmentation tasks."""
 
 from eva.core.metrics import structs
-from eva.vision.metrics.segmentation import generalized_dice, mean_iou
+from eva.vision.metrics.segmentation import dice, mean_iou
 
 
 class MulticlassSegmentationMetrics(structs.MetricCollection):
@@ -26,19 +26,31 @@ class MulticlassSegmentationMetrics(structs.MetricCollection):
             postfix: A string to add after the keys in the output dictionary.
         """
         super().__init__(
-            metrics=[
-                generalized_dice.GeneralizedDiceScore(
+            metrics={
+                "DiceScore (micro)": dice.DiceScore(
                     num_classes=num_classes,
                     include_background=include_background,
-                    weight_type="linear",
+                    average="micro",
                     ignore_index=ignore_index,
                 ),
-                mean_iou.MeanIoU(
+                "DiceScore (macro)": dice.DiceScore(
+                    num_classes=num_classes,
+                    include_background=include_background,
+                    average="macro",
+                    ignore_index=ignore_index,
+                ),
+                # "DiceScore (weighted)": dice.DiceScore(
+                #     num_classes=num_classes,
+                #     include_background=include_background,
+                #     average="weighted",
+                #     ignore_index=ignore_index,
+                # ), # TODO: for some reason this doesn't work when calculating also micro & macro
+                "MeanIoU": mean_iou.MeanIoU(
                     num_classes=num_classes,
                     include_background=include_background,
                     ignore_index=ignore_index,
                 ),
-            ],
+            },
             prefix=prefix,
             postfix=postfix,
         )

--- a/src/eva/vision/metrics/defaults/segmentation/multiclass.py
+++ b/src/eva/vision/metrics/defaults/segmentation/multiclass.py
@@ -27,6 +27,18 @@ class MulticlassSegmentationMetrics(structs.MetricCollection):
         """
         super().__init__(
             metrics={
+                "MonaiDiceScore": segmentation.MonaiDiceScore(
+                    num_classes=num_classes,
+                    include_background=include_background,
+                    ignore_index=ignore_index,
+                    ignore_empty=True,
+                ),
+                "MonaiDiceScore (ignore_empty=False)": segmentation.MonaiDiceScore(
+                    num_classes=num_classes,
+                    include_background=include_background,
+                    ignore_index=ignore_index,
+                    ignore_empty=False,
+                ),
                 "DiceScore (micro)": segmentation.DiceScore(
                     num_classes=num_classes,
                     include_background=include_background,

--- a/src/eva/vision/metrics/defaults/segmentation/multiclass.py
+++ b/src/eva/vision/metrics/defaults/segmentation/multiclass.py
@@ -1,7 +1,7 @@
 """Default metric collection for multiclass semantic segmentation tasks."""
 
 from eva.core.metrics import structs
-from eva.vision.metrics.segmentation import dice, mean_iou
+from eva.vision.metrics import segmentation
 
 
 class MulticlassSegmentationMetrics(structs.MetricCollection):
@@ -27,25 +27,25 @@ class MulticlassSegmentationMetrics(structs.MetricCollection):
         """
         super().__init__(
             metrics={
-                "DiceScore (micro)": dice.DiceScore(
+                "DiceScore (micro)": segmentation.DiceScore(
                     num_classes=num_classes,
                     include_background=include_background,
                     average="micro",
                     ignore_index=ignore_index,
                 ),
-                "DiceScore (macro)": dice.DiceScore(
+                "DiceScore (macro)": segmentation.DiceScore(
                     num_classes=num_classes,
                     include_background=include_background,
                     average="macro",
                     ignore_index=ignore_index,
                 ),
-                # "DiceScore (weighted)": dice.DiceScore(
-                #     num_classes=num_classes,
-                #     include_background=include_background,
-                #     average="weighted",
-                #     ignore_index=ignore_index,
-                # ), # TODO: for some reason this doesn't work when calculating also micro & macro
-                "MeanIoU": mean_iou.MeanIoU(
+                "DiceScore (weighted)": segmentation.DiceScore(
+                    num_classes=num_classes,
+                    include_background=include_background,
+                    average="weighted",
+                    ignore_index=ignore_index,
+                ),
+                "MeanIoU": segmentation.MeanIoU(
                     num_classes=num_classes,
                     include_background=include_background,
                     ignore_index=ignore_index,
@@ -53,4 +53,5 @@ class MulticlassSegmentationMetrics(structs.MetricCollection):
             },
             prefix=prefix,
             postfix=postfix,
+            compute_groups=False,
         )

--- a/src/eva/vision/metrics/defaults/segmentation/multiclass.py
+++ b/src/eva/vision/metrics/defaults/segmentation/multiclass.py
@@ -53,5 +53,4 @@ class MulticlassSegmentationMetrics(structs.MetricCollection):
             },
             prefix=prefix,
             postfix=postfix,
-            compute_groups=False,
         )

--- a/src/eva/vision/metrics/segmentation/__init__.py
+++ b/src/eva/vision/metrics/segmentation/__init__.py
@@ -1,9 +1,11 @@
 """Segmentation metrics API."""
 
+from eva.vision.metrics.segmentation.dice import DiceScore
 from eva.vision.metrics.segmentation.generalized_dice import GeneralizedDiceScore
 from eva.vision.metrics.segmentation.mean_iou import MeanIoU
 
 __all__ = [
+    "DiceScore",
     "GeneralizedDiceScore",
     "MeanIoU",
 ]

--- a/src/eva/vision/metrics/segmentation/__init__.py
+++ b/src/eva/vision/metrics/segmentation/__init__.py
@@ -3,9 +3,11 @@
 from eva.vision.metrics.segmentation.dice import DiceScore
 from eva.vision.metrics.segmentation.generalized_dice import GeneralizedDiceScore
 from eva.vision.metrics.segmentation.mean_iou import MeanIoU
+from eva.vision.metrics.segmentation.monai_dice import MonaiDiceScore
 
 __all__ = [
     "DiceScore",
+    "MonaiDiceScore",
     "GeneralizedDiceScore",
     "MeanIoU",
 ]

--- a/src/eva/vision/metrics/segmentation/_utils.py
+++ b/src/eva/vision/metrics/segmentation/_utils.py
@@ -6,7 +6,7 @@ import torch
 
 
 def apply_ignore_index(
-    preds: torch.Tensor, target: torch.Tensor, ignore_index: int, num_classes: int
+    preds: torch.Tensor, target: torch.Tensor, ignore_index: int
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Applies the ignore index to the predictions and target tensors.
 
@@ -17,7 +17,6 @@ def apply_ignore_index(
         preds: The predictions tensor. Expected to be of shape `(N,C,...)`.
         target: The target tensor. Expected to be of shape `(N,C,...)`.
         ignore_index: The index to ignore.
-        num_classes: The number of classes.
 
     Returns:
         The modified predictions and target tensors of shape `(N,C-1,...)`.

--- a/src/eva/vision/metrics/segmentation/dice.py
+++ b/src/eva/vision/metrics/segmentation/dice.py
@@ -4,6 +4,7 @@ from typing import Any, Literal
 
 import torch
 from torchmetrics import segmentation
+from torchmetrics.functional.segmentation.dice import _dice_score_update
 from typing_extensions import override
 
 from eva.vision.metrics.segmentation import _utils
@@ -29,8 +30,8 @@ class DiceScore(segmentation.DiceScore):
         Args:
             num_classes: The number of classes in the segmentation problem.
             include_background: Whether to include the background class in the computation
-            weight_type: The type of weight to apply to each class. Can be one of `"square"`,
-                `"simple"`, or `"linear"`.
+            average: The method to average the dice score accross the different classes. Options are
+                `"micro"`, `"macro"`, `"weighted"`, `"none"` or `None`.
             ignore_index: Integer specifying a target class to ignore. If given, this class
                 index does not contribute to the returned score, regardless of reduction method.
             kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
@@ -55,4 +56,16 @@ class DiceScore(segmentation.DiceScore):
             preds, target = _utils.apply_ignore_index(
                 preds, target, self.ignore_index, self.num_classes
             )
-        super().update(preds=preds.long(), target=target.long())
+
+        # TODO: Replace _update by super.update() once the following issue is fixed:
+        # https://github.com/Lightning-AI/torchmetrics/issues/2847
+        self._update(preds.long(), target.long())
+        # super().update(preds=preds.long(), target=target.long())
+
+    def _update(self, preds: torch.Tensor, target: torch.Tensor) -> None:
+        numerator, denominator, support = _dice_score_update(
+            preds, target, self.num_classes, self.include_background, self.input_format  # type: ignore
+        )
+        self.numerator.append(numerator)
+        self.denominator.append(denominator)
+        self.support.append(support)

--- a/src/eva/vision/metrics/segmentation/dice.py
+++ b/src/eva/vision/metrics/segmentation/dice.py
@@ -9,7 +9,7 @@ from typing_extensions import override
 from eva.vision.metrics.segmentation import _utils
 
 
-class GeneralizedDiceScore(segmentation.GeneralizedDiceScore):
+class DiceScore(segmentation.DiceScore):
     """Defines the Generalized Dice Score.
 
     It expands the `torchmetrics` class by including an `ignore_index`
@@ -20,9 +20,8 @@ class GeneralizedDiceScore(segmentation.GeneralizedDiceScore):
         self,
         num_classes: int,
         include_background: bool = True,
-        weight_type: Literal["square", "simple", "linear"] = "linear",
+        average: Literal["micro", "macro", "weighted", "none"] | None = "micro",
         ignore_index: int | None = None,
-        per_class: bool = False,
         **kwargs: Any,
     ) -> None:
         """Initializes the metric.
@@ -34,8 +33,6 @@ class GeneralizedDiceScore(segmentation.GeneralizedDiceScore):
                 `"simple"`, or `"linear"`.
             ignore_index: Integer specifying a target class to ignore. If given, this class
                 index does not contribute to the returned score, regardless of reduction method.
-            per_class: Whether to compute the IoU for each class separately. If set to ``False``,
-                the metric will compute the mean IoU over all classes.
             kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
         """
         super().__init__(
@@ -43,8 +40,8 @@ class GeneralizedDiceScore(segmentation.GeneralizedDiceScore):
             - (ignore_index is not None)
             + (ignore_index == 0 and not include_background),
             include_background=include_background,
-            weight_type=weight_type,
-            per_class=per_class,
+            average=average,
+            input_format="one-hot",
             **kwargs,
         )
         self.orig_num_classes = num_classes

--- a/src/eva/vision/metrics/segmentation/dice.py
+++ b/src/eva/vision/metrics/segmentation/dice.py
@@ -53,9 +53,7 @@ class DiceScore(segmentation.DiceScore):
         preds = _utils.index_to_one_hot(preds, num_classes=self.orig_num_classes)
         target = _utils.index_to_one_hot(target, num_classes=self.orig_num_classes)
         if self.ignore_index is not None:
-            preds, target = _utils.apply_ignore_index(
-                preds, target, self.ignore_index, self.num_classes
-            )
+            preds, target = _utils.apply_ignore_index(preds, target, self.ignore_index)
 
         # TODO: Replace _update by super.update() once the following issue is fixed:
         # https://github.com/Lightning-AI/torchmetrics/issues/2847

--- a/src/eva/vision/metrics/segmentation/generalized_dice.py
+++ b/src/eva/vision/metrics/segmentation/generalized_dice.py
@@ -55,7 +55,5 @@ class GeneralizedDiceScore(segmentation.GeneralizedDiceScore):
         preds = _utils.index_to_one_hot(preds, num_classes=self.orig_num_classes)
         target = _utils.index_to_one_hot(target, num_classes=self.orig_num_classes)
         if self.ignore_index is not None:
-            preds, target = _utils.apply_ignore_index(
-                preds, target, self.ignore_index, self.num_classes
-            )
+            preds, target = _utils.apply_ignore_index(preds, target, self.ignore_index)
         super().update(preds=preds.long(), target=target.long())

--- a/src/eva/vision/metrics/segmentation/mean_iou.py
+++ b/src/eva/vision/metrics/segmentation/mean_iou.py
@@ -36,10 +36,8 @@ class MeanIoU(segmentation.MeanIoU):
             kwargs: Additional keyword arguments, see :ref:`Metric kwargs` for more info.
         """
         super().__init__(
-            num_classes=num_classes
-            - (ignore_index is not None)
-            + (ignore_index == 0 and not include_background),
-            include_background=include_background,
+            include_background=include_background or (ignore_index == 0),
+            num_classes=num_classes - (ignore_index is not None),
             per_class=per_class,
             **kwargs,
         )
@@ -51,7 +49,5 @@ class MeanIoU(segmentation.MeanIoU):
         preds = _utils.index_to_one_hot(preds, num_classes=self.orig_num_classes)
         target = _utils.index_to_one_hot(target, num_classes=self.orig_num_classes)
         if self.ignore_index is not None:
-            preds, target = _utils.apply_ignore_index(
-                preds, target, self.ignore_index, self.num_classes
-            )
+            preds, target = _utils.apply_ignore_index(preds, target, self.ignore_index)
         super().update(preds=preds.long(), target=target.long())

--- a/src/eva/vision/metrics/segmentation/mean_iou.py
+++ b/src/eva/vision/metrics/segmentation/mean_iou.py
@@ -13,7 +13,7 @@ class MeanIoU(segmentation.MeanIoU):
     """MeanIoU (mIOU) metric for semantic segmentation.
 
     It expands the `torchmetrics` class by including an `ignore_index`
-    functionality.
+    functionality and converting tensors to one-hot format.
     """
 
     def __init__(

--- a/src/eva/vision/metrics/segmentation/monai_dice.py
+++ b/src/eva/vision/metrics/segmentation/monai_dice.py
@@ -1,0 +1,59 @@
+"""Wrapper for dice score metric from MONAI."""
+
+from monai.metrics.meandice import DiceMetric
+from typing_extensions import override
+
+from eva.vision.metrics import wrappers
+from eva.vision.metrics.segmentation import _utils
+
+
+class MonaiDiceScore(wrappers.MonaiMetricWrapper):
+    """Wrapper to make MONAI's `DiceMetric` compatible with `torchmetrics`."""
+
+    def __init__(
+        self,
+        num_classes: int,
+        include_background: bool = True,
+        reduction: str = "mean",
+        ignore_index: int | None = None,
+        **kwargs,
+    ):
+        """Initializes metric.
+
+        Args:
+            num_classes: The number of classes in the dataset.
+            include_background: Whether to include the background class in the computation.
+            reduction: The method to reduce the dice score. Options are `"mean"`, `"sum"`, `"none"`.
+            ignore_index: Integer specifying a target class to ignore. If given, this class
+                index does not contribute to the returned score.
+            kwargs: Additional keyword arguments for instantiating monai's `DiceMetric` class.
+        """
+        super().__init__(
+            DiceMetric(
+                include_background=include_background,
+                reduction=reduction,
+                num_classes=num_classes,
+                **kwargs,
+            )
+        )
+
+        self.reduction = reduction
+        self.num_classes = num_classes
+        self.ignore_index = ignore_index
+
+    @override
+    def update(self, preds, target):
+        preds = _utils.index_to_one_hot(preds, num_classes=self.num_classes)
+        target = _utils.index_to_one_hot(target, num_classes=self.num_classes)
+        if self.ignore_index is not None:
+            preds, target = _utils.apply_ignore_index(
+                preds, target, self.ignore_index, self.num_classes
+            )
+        return super().update(preds, target)
+
+    @override
+    def compute(self):
+        result = super().compute()
+        if self.reduction == "none" and len(result) > 1:
+            result = result.nanmean(dim=0)
+        return result

--- a/src/eva/vision/metrics/segmentation/monai_dice.py
+++ b/src/eva/vision/metrics/segmentation/monai_dice.py
@@ -30,25 +30,23 @@ class MonaiDiceScore(wrappers.MonaiMetricWrapper):
         """
         super().__init__(
             DiceMetric(
-                include_background=include_background,
+                include_background=include_background or (ignore_index == 0),
                 reduction=reduction,
-                num_classes=num_classes,
+                num_classes=num_classes - (ignore_index is not None),
                 **kwargs,
             )
         )
 
         self.reduction = reduction
-        self.num_classes = num_classes
+        self.orig_num_classes = num_classes
         self.ignore_index = ignore_index
 
     @override
     def update(self, preds, target):
-        preds = _utils.index_to_one_hot(preds, num_classes=self.num_classes)
-        target = _utils.index_to_one_hot(target, num_classes=self.num_classes)
+        preds = _utils.index_to_one_hot(preds, num_classes=self.orig_num_classes)
+        target = _utils.index_to_one_hot(target, num_classes=self.orig_num_classes)
         if self.ignore_index is not None:
-            preds, target = _utils.apply_ignore_index(
-                preds, target, self.ignore_index, self.num_classes
-            )
+            preds, target = _utils.apply_ignore_index(preds, target, self.ignore_index)
         return super().update(preds, target)
 
     @override

--- a/src/eva/vision/metrics/wrappers/__init__.py
+++ b/src/eva/vision/metrics/wrappers/__init__.py
@@ -1,0 +1,5 @@
+"""Metrics wrappers API."""
+
+from eva.vision.metrics.wrappers.monai import MonaiMetricWrapper
+
+__all__ = ["MonaiMetricWrapper"]

--- a/src/eva/vision/metrics/wrappers/monai.py
+++ b/src/eva/vision/metrics/wrappers/monai.py
@@ -1,0 +1,32 @@
+"""Monai metrics wrappers."""
+
+import torch
+import torchmetrics
+from monai.metrics.metric import CumulativeIterationMetric
+from typing_extensions import override
+
+
+class MonaiMetricWrapper(torchmetrics.Metric):
+    """Wrapper class to make MONAI metrics compatible with `torchmetrics`."""
+
+    def __init__(self, monai_metric: CumulativeIterationMetric):
+        """Initializes the monai metric wrapper.
+
+        Args:
+            monai_metric: The MONAI metric to wrap.
+        """
+        super().__init__()
+        self._monai_metric = monai_metric
+
+    @override
+    def update(self, preds: torch.Tensor, target: torch.Tensor) -> None:
+        self._monai_metric(preds, target)
+
+    @override
+    def compute(self) -> torch.Tensor:
+        return self._monai_metric.aggregate()
+
+    @override
+    def reset(self) -> None:
+        super().reset()
+        self._monai_metric.reset()

--- a/tests/eva/vision/metrics/defaults/segmentation/test_multiclass.py
+++ b/tests/eva/vision/metrics/defaults/segmentation/test_multiclass.py
@@ -13,7 +13,9 @@ NUM_CLASSES_ONE = 3
 PREDS_ONE = torch.randint(0, NUM_CLASSES_ONE, (NUM_BATCHES, BATCH_SIZE, 32, 32))
 TARGET_ONE = torch.randint(0, NUM_CLASSES_ONE, (NUM_BATCHES, BATCH_SIZE, 32, 32))
 EXPECTED_ONE = {
-    "GeneralizedDiceScore": torch.tensor(0.3482658863067627),
+    "DiceScore (micro)": torch.tensor(0.3482658863067627),
+    "DiceScore (macro)": torch.tensor(0.34805023670196533),
+    "DiceScore (weighted)": torch.tensor(0.3484232723712921),
     "MeanIoU": torch.tensor(0.2109210342168808),
 }
 """Test features."""

--- a/tests/eva/vision/metrics/defaults/segmentation/test_multiclass.py
+++ b/tests/eva/vision/metrics/defaults/segmentation/test_multiclass.py
@@ -13,12 +13,15 @@ NUM_CLASSES_ONE = 3
 PREDS_ONE = torch.randint(0, NUM_CLASSES_ONE, (NUM_BATCHES, BATCH_SIZE, 32, 32))
 TARGET_ONE = torch.randint(0, NUM_CLASSES_ONE, (NUM_BATCHES, BATCH_SIZE, 32, 32))
 EXPECTED_ONE = {
+    "MonaiDiceScore": torch.tensor(0.34805023670196533),
+    "MonaiDiceScore (ignore_empty=False)": torch.tensor(0.34805023670196533),
     "DiceScore (micro)": torch.tensor(0.3482658863067627),
     "DiceScore (macro)": torch.tensor(0.34805023670196533),
     "DiceScore (weighted)": torch.tensor(0.3484232723712921),
     "MeanIoU": torch.tensor(0.2109210342168808),
 }
 """Test features."""
+assert EXPECTED_ONE["MonaiDiceScore (ignore_empty=False)"] == EXPECTED_ONE["DiceScore (macro)"]
 
 
 @pytest.mark.parametrize(

--- a/tests/eva/vision/metrics/segmentation/test_dice.py
+++ b/tests/eva/vision/metrics/segmentation/test_dice.py
@@ -1,0 +1,48 @@
+"""DiceScore metric tests."""
+
+from typing import Tuple
+
+import pytest
+import torch
+
+from eva.vision.metrics import segmentation
+from tests.eva.vision.metrics.segmentation import _utils
+
+
+@pytest.mark.parametrize(
+    "batch_size, num_classes, image_size, ignore_index",
+    [
+        (4, 3, (16, 16), 0),
+        (16, 5, (20, 20), 1),
+    ],
+)
+def test_ignore_index(
+    batch_size: int, num_classes: int, image_size: Tuple[int, int], ignore_index: int
+) -> None:
+    """Tests the `ignore_index` functionality."""
+    _utils._test_ignore_index(
+        segmentation.DiceScore, batch_size, num_classes, image_size, ignore_index
+    )
+
+
+def test_expected_scores_classwise():
+    """Tests the expected score values when calculating class-wise scores."""
+    n_samples, n_classes = 4, 3
+
+    target = torch.full((n_samples, n_classes, 128, 128), 0, dtype=torch.int8)
+    preds = torch.full((n_samples, n_classes, 128, 128), 0, dtype=torch.int8)
+    perfect_preds = preds.clone()
+
+    target[0, 0], perfect_preds[0, 0] = 1, 1
+    target[2, 1], perfect_preds[2, 1] = 1, 1
+
+    metric = segmentation.DiceScore(num_classes=n_classes, average="none")
+    scores = metric(perfect_preds, target)
+
+    assert scores.tolist() == [1.0] * n_classes
+
+    preds_with_errors = preds.clone()
+    preds_with_errors[0, 0] = 1
+
+    scores = metric(preds_with_errors, target)
+    assert scores.tolist() == [1.0, 0.75, 1.0]

--- a/tests/eva/vision/test_vision_cli.py
+++ b/tests/eva/vision/test_vision_cli.py
@@ -24,7 +24,7 @@ from tests.eva import _cli
         "configs/vision/pathology/online/segmentation/bcss.yaml",
         "configs/vision/pathology/online/segmentation/consep.yaml",
         "configs/vision/pathology/online/segmentation/monusac.yaml",
-        "configs/vision/pathology/online/segmentation/total_segmentator_2d.yaml",
+        "configs/vision/radiology/online/segmentation/total_segmentator_2d.yaml",
         "configs/vision/radiology/online/segmentation/lits.yaml",
         # | offline
         # classification
@@ -38,7 +38,7 @@ from tests.eva import _cli
         "configs/vision/pathology/offline/segmentation/bcss.yaml",
         "configs/vision/pathology/offline/segmentation/consep.yaml",
         "configs/vision/pathology/offline/segmentation/monusac.yaml",
-        "configs/vision/pathology/offline/segmentation/total_segmentator_2d.yaml",
+        "configs/vision/radiology/offline/segmentation/total_segmentator_2d.yaml",
         "configs/vision/radiology/offline/segmentation/lits.yaml",
     ],
 )


### PR DESCRIPTION
Closes #718

Used `DiceMetric` from MONAI for class-wise scores, because in torchmetrics there is an open issue for this:
https://github.com/Lightning-AI/torchmetrics/issues/2851