### PR TITLE
Change learning rate for segmentation configs to `0.002`

### DIFF
--- a/configs/vision/pathology/offline/segmentation/bcss.yaml
+++ b/configs/vision/pathology/offline/segmentation/bcss.yaml
@@ -65,7 +65,7 @@ model:
     optimizer:
       class_path: torch.optim.AdamW
       init_args:
-        lr: ${oc.env:LR_VALUE, 0.0001}
+        lr: ${oc.env:LR_VALUE, 0.002}
     lr_scheduler:
       class_path: torch.optim.lr_scheduler.PolynomialLR
       init_args:

--- a/configs/vision/pathology/offline/segmentation/consep.yaml
+++ b/configs/vision/pathology/offline/segmentation/consep.yaml
@@ -65,7 +65,7 @@ model:
     optimizer:
       class_path: torch.optim.AdamW
       init_args:
-        lr: ${oc.env:LR_VALUE, 0.0001}
+        lr: ${oc.env:LR_VALUE, 0.002}
     lr_scheduler:
       class_path: torch.optim.lr_scheduler.PolynomialLR
       init_args:

--- a/configs/vision/pathology/offline/segmentation/monusac.yaml
+++ b/configs/vision/pathology/offline/segmentation/monusac.yaml
@@ -67,7 +67,7 @@ model:
     optimizer:
       class_path: torch.optim.AdamW
       init_args:
-        lr: ${oc.env:LR_VALUE, 0.0001}
+        lr: ${oc.env:LR_VALUE, 0.002}
     lr_scheduler:
       class_path: torch.optim.lr_scheduler.PolynomialLR
       init_args:

--- a/configs/vision/pathology/online/segmentation/consep.yaml
+++ b/configs/vision/pathology/online/segmentation/consep.yaml
@@ -58,7 +58,7 @@ model:
     optimizer:
       class_path: torch.optim.AdamW
       init_args:
-        lr: ${oc.env:LR_VALUE, 0.0001}
+        lr: ${oc.env:LR_VALUE, 0.002}
     lr_scheduler:
       class_path: torch.optim.lr_scheduler.PolynomialLR
       init_args:

--- a/configs/vision/pathology/online/segmentation/monusac.yaml
+++ b/configs/vision/pathology/online/segmentation/monusac.yaml
@@ -59,7 +59,7 @@ model:
     optimizer:
       class_path: torch.optim.AdamW
       init_args:
-        lr: ${oc.env:LR_VALUE, 0.0001}
+        lr: ${oc.env:LR_VALUE, 0.002}
     lr_scheduler:
       class_path: torch.optim.lr_scheduler.PolynomialLR
       init_args:

--- a/docs/leaderboards.md
+++ b/docs/leaderboards.md
@@ -40,7 +40,7 @@ We selected this approach to prioritize reliable, robust and fair FM-evaluation 
 | **Output activation function** | none                      | none                      | none                      |
 | **Number of steps**            | 12,500                    | 12,500 (1)                | 2,000                     |
 | **Base batch size**            | 256                       | 32                        | 64                        |
-| **Base learning rate**         | 0.0003                    | 0.001                     | 0.0001                    |
+| **Base learning rate**         | 0.0003                    | 0.001                     | 0.002                    |
 | **Early stopping**             | 5% * [Max epochs]         | 10% * [Max epochs] (2)    | 10% * [Max epochs] (2)    |
 | **Optimizer**                  | SGD                       | AdamW                     | AdamW                     |
 | **Momentum**                   | 0.9                       | n/a                       | n/a                       |

--- a/src/eva/core/models/__init__.py
+++ b/src/eva/core/models/__init__.py
@@ -2,7 +2,13 @@
 
 from eva.core.models.modules import HeadModule, InferenceModule
 from eva.core.models.networks import MLP
-from eva.core.models.wrappers import BaseModel, HuggingFaceModel, ModelFromFunction, ONNXModel
+from eva.core.models.wrappers import (
+    BaseModel,
+    HuggingFaceModel,
+    ModelFromFunction,
+    ONNXModel,
+    TorchHubModel,
+)
 
 __all__ = [
     "HeadModule",
@@ -12,4 +18,5 @@ __all__ = [
     "HuggingFaceModel",
     "ModelFromFunction",
     "ONNXModel",
+    "TorchHubModel",
 ]

--- a/src/eva/core/models/wrappers/from_torchhub.py
+++ b/src/eva/core/models/wrappers/from_torchhub.py
@@ -1,6 +1,6 @@
 """Model wrapper for torch.hub models."""
 
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 import torch
 import torch.nn as nn
@@ -72,7 +72,7 @@ class TorchHubModel(wrappers.BaseModel):
         TorchHubModel.__name__ = self._model_name
 
     @override
-    def model_forward(self, tensor: torch.Tensor) -> torch.Tensor:
+    def model_forward(self, tensor: torch.Tensor) -> torch.Tensor | List[torch.Tensor]:
         if self._out_indices is not None:
             if not hasattr(self._model, "get_intermediate_layers"):
                 raise ValueError(
@@ -80,8 +80,14 @@ class TorchHubModel(wrappers.BaseModel):
                     "when using `out_indices`."
                 )
 
-            return self._model.get_intermediate_layers(
-                tensor, self._out_indices, reshape=True, return_class_token=False, norm=self._norm
+            return list(
+                self._model.get_intermediate_layers(
+                    tensor,
+                    self._out_indices,
+                    reshape=True,
+                    return_class_token=False,
+                    norm=self._norm,
+                )
             )
 
         return self._model(tensor)

--- a/src/eva/vision/models/wrappers/from_timm.py
+++ b/src/eva/vision/models/wrappers/from_timm.py
@@ -43,7 +43,7 @@ class TimmModel(wrappers.BaseModel):
         self._pretrained = pretrained
         self._checkpoint_path = checkpoint_path
         self._out_indices = out_indices
-        self._model_kwargs = model_kwargs or {}
+        self._model_kwargs = model_kwargs or {"dynamic_img_size": True}
 
         self.load_model()
 

--- a/src/eva/vision/models/wrappers/from_timm.py
+++ b/src/eva/vision/models/wrappers/from_timm.py
@@ -43,7 +43,7 @@ class TimmModel(wrappers.BaseModel):
         self._pretrained = pretrained
         self._checkpoint_path = checkpoint_path
         self._out_indices = out_indices
-        self._model_kwargs = model_kwargs or {"dynamic_img_size": True}
+        self._model_kwargs = model_kwargs or {}
 
         self.load_model()
 


### PR DESCRIPTION
Turns out that `0.0001` is too low, leading to some evals not converging.
`0.002` seems to work well across all current models.