### PR TITLE
Set shuffle option in train dataloader back to true in consep config

### DIFF
--- a/configs/vision/pathology/online/segmentation/consep.yaml
+++ b/configs/vision/pathology/online/segmentation/consep.yaml
@@ -116,7 +116,7 @@ data:
       train:
         batch_size: &BATCH_SIZE ${oc.env:BATCH_SIZE, 64}
         num_workers: &N_DATA_WORKERS ${oc.env:N_DATA_WORKERS, 4}
-        shuffle: false
+        shuffle: true
       val:
         batch_size: *BATCH_SIZE
         num_workers: *N_DATA_WORKERS


### PR DESCRIPTION
By accident the `shuffle` argument for the train data loader of consep was set to `false` here:
https://github.com/kaiko-ai/eva/pull/719/