### PR TITLE
Add missing coordinate checks to sampler unit tests

### DIFF
--- a/tests/eva/vision/data/wsi/patching/samplers/test_foreground_grid.py
+++ b/tests/eva/vision/data/wsi/patching/samplers/test_foreground_grid.py
@@ -55,6 +55,7 @@ def test_same_seed(max_samples: int, seed: int, x_y_expected: list) -> None:
     x_y_2 = list(sampler.sample(**TEST_ARGS))
 
     assert x_y_1 == x_y_2
+    assert x_y_1 == x_y_expected
 
 
 @pytest.mark.parametrize("max_samples, seed_1, seed_2", [(3, 1, 2), (5, 3, 4)])

--- a/tests/eva/vision/data/wsi/patching/samplers/test_random.py
+++ b/tests/eva/vision/data/wsi/patching/samplers/test_random.py
@@ -48,6 +48,7 @@ def test_same_seed(n_samples: int, seed: int, x_y_expected: int) -> None:
     x_y_2 = list(sampler_2.sample(**TEST_ARGS))
 
     assert x_y_1 == x_y_2
+    assert x_y_1 == x_y_expected
 
 
 @pytest.mark.parametrize("n_samples, seed_1, seed_2", [(10, 1, 2), (22, 3, 4)])


### PR DESCRIPTION
The assert to check wether the values of the extracted coordinates match the expected values given a specific seed were missing.