### PR TITLE
Replace input/output type hints in `BaseModel` by type vars

### DIFF
--- a/src/eva/core/models/wrappers/base.py
+++ b/src/eva/core/models/wrappers/base.py
@@ -1,40 +1,43 @@
 """Base class for model wrappers."""
 
 import abc
-from typing import Callable
+from typing import Callable, Generic, TypeVar
 
-import torch
 import torch.nn as nn
 from typing_extensions import override
 
+InputType = TypeVar("InputType")
+"""The input data type."""
+OutputType = TypeVar("OutputType")
+"""The output data type."""
 
-class BaseModel(nn.Module):
+
+class BaseModel(nn.Module, Generic[InputType, OutputType]):
     """Base class for model wrappers."""
 
-    def __init__(self, tensor_transforms: Callable | None = None) -> None:
+    def __init__(self, transforms: Callable | None = None) -> None:
         """Initializes the model.
 
         Args:
-            tensor_transforms: The transforms to apply to the output
-                tensor produced by the model.
+            transforms: The transforms to apply to the output produced by the model.
         """
         super().__init__()
 
-        self._output_transforms = tensor_transforms
+        self._output_transforms = transforms
 
-        self._model: Callable[..., torch.Tensor] | nn.Module
+        self._model: Callable[..., OutputType] | nn.Module
 
     @override
-    def forward(self, tensor: torch.Tensor) -> torch.Tensor:
-        tensor = self.model_forward(tensor)
-        return self._apply_transforms(tensor)
+    def forward(self, tensor: InputType) -> OutputType:
+        out = self.model_forward(tensor)
+        return self._apply_transforms(out)
 
     @abc.abstractmethod
-    def load_model(self) -> Callable[..., torch.Tensor]:
+    def load_model(self) -> Callable[..., OutputType]:
         """Loads the model."""
         raise NotImplementedError
 
-    def model_forward(self, tensor: torch.Tensor) -> torch.Tensor:
+    def model_forward(self, tensor: InputType) -> OutputType:
         """Implements the forward pass of the model.
 
         Args:
@@ -42,7 +45,7 @@ class BaseModel(nn.Module):
         """
         return self._model(tensor)
 
-    def _apply_transforms(self, tensor: torch.Tensor) -> torch.Tensor:
+    def _apply_transforms(self, tensor: OutputType) -> OutputType:
         if self._output_transforms is not None:
             tensor = self._output_transforms(tensor)
         return tensor

--- a/src/eva/core/models/wrappers/from_function.py
+++ b/src/eva/core/models/wrappers/from_function.py
@@ -3,13 +3,14 @@
 from typing import Any, Callable, Dict
 
 import jsonargparse
+import torch
 from torch import nn
 from typing_extensions import override
 
 from eva.core.models.wrappers import _utils, base
 
 
-class ModelFromFunction(base.BaseModel):
+class ModelFromFunction(base.BaseModel[torch.Tensor, torch.Tensor]):
     """Wrapper class for models which are initialized from functions.
 
     This is helpful for initializing models in a `.yaml` configuration file.
@@ -20,7 +21,7 @@ class ModelFromFunction(base.BaseModel):
         path: Callable[..., nn.Module],
         arguments: Dict[str, Any] | None = None,
         checkpoint_path: str | None = None,
-        tensor_transforms: Callable | None = None,
+        transforms: Callable | None = None,
     ) -> None:
         """Initializes and constructs the model.
 
@@ -31,10 +32,10 @@ class ModelFromFunction(base.BaseModel):
                 weights from. This is currently only supported for torch
                 model checkpoints. For other formats, the checkpoint loading
                 should be handled within the provided callable object in <path>.
-            tensor_transforms: The transforms to apply to the output tensor
+            transforms: The transforms to apply to the output tensor
                 produced by the model.
         """
-        super().__init__(tensor_transforms=tensor_transforms)
+        super().__init__(transforms=transforms)
 
         self._path = path
         self._arguments = arguments

--- a/src/eva/core/models/wrappers/from_torchhub.py
+++ b/src/eva/core/models/wrappers/from_torchhub.py
@@ -6,11 +6,10 @@ import torch
 import torch.nn as nn
 from typing_extensions import override
 
-from eva.core.models import wrappers
-from eva.core.models.wrappers import _utils
+from eva.core.models.wrappers import _utils, base
 
 
-class TorchHubModel(wrappers.BaseModel):
+class TorchHubModel(base.BaseModel[torch.Tensor, torch.Tensor]):
     """Model wrapper for `torch.hub` models."""
 
     def __init__(
@@ -23,7 +22,7 @@ class TorchHubModel(wrappers.BaseModel):
         norm: bool = False,
         trust_repo: bool = True,
         model_kwargs: Dict[str, Any] | None = None,
-        tensor_transforms: Callable | None = None,
+        transforms: Callable | None = None,
     ) -> None:
         """Initializes the encoder.
 
@@ -39,10 +38,10 @@ class TorchHubModel(wrappers.BaseModel):
             trust_repo: If set to `False`, a prompt will ask the user whether the
                 repo should be trusted.
             model_kwargs: Extra model arguments.
-            tensor_transforms: The transforms to apply to the output tensor
+            transforms: The transforms to apply to the output tensor
                 produced by the model.
         """
-        super().__init__(tensor_transforms=tensor_transforms)
+        super().__init__(transforms=transforms)
 
         self._model_name = model_name
         self._repo_or_dir = repo_or_dir

--- a/src/eva/core/models/wrappers/huggingface.py
+++ b/src/eva/core/models/wrappers/huggingface.py
@@ -2,19 +2,20 @@
 
 from typing import Any, Callable, Dict
 
+import torch
 import transformers
 from typing_extensions import override
 
 from eva.core.models.wrappers import base
 
 
-class HuggingFaceModel(base.BaseModel):
+class HuggingFaceModel(base.BaseModel[torch.Tensor, torch.Tensor]):
     """Wrapper class for loading HuggingFace `transformers` models."""
 
     def __init__(
         self,
         model_name_or_path: str,
-        tensor_transforms: Callable | None = None,
+        transforms: Callable | None = None,
         model_kwargs: Dict[str, Any] | None = None,
     ) -> None:
         """Initializes the model.
@@ -23,11 +24,11 @@ class HuggingFaceModel(base.BaseModel):
             model_name_or_path: The model name or path to load the model from.
                 This can be a local path or a model name from the `HuggingFace`
                 model hub.
-            tensor_transforms: The transforms to apply to the output tensor
+            transforms: The transforms to apply to the output tensor
                 produced by the model.
             model_kwargs: The arguments used for instantiating the model.
         """
-        super().__init__(tensor_transforms=tensor_transforms)
+        super().__init__(transforms=transforms)
 
         self._model_name_or_path = model_name_or_path
         self._model_kwargs = model_kwargs or {}

--- a/src/eva/core/models/wrappers/onnx.py
+++ b/src/eva/core/models/wrappers/onnx.py
@@ -9,23 +9,23 @@ from typing_extensions import override
 from eva.core.models.wrappers import base
 
 
-class ONNXModel(base.BaseModel):
+class ONNXModel(base.BaseModel[torch.Tensor, torch.Tensor]):
     """Wrapper class for loading ONNX models."""
 
     def __init__(
         self,
         path: str,
         device: Literal["cpu", "cuda"] | None = "cpu",
-        tensor_transforms: Callable | None = None,
+        transforms: Callable | None = None,
     ):
         """Initializes the model.
 
         Args:
             path: The path to the .onnx model file.
             device: The device to run the model on. This can be either "cpu" or "cuda".
-            tensor_transforms: The transforms to apply to the output tensor produced by the model.
+            transforms: The transforms to apply to the output tensor produced by the model.
         """
-        super().__init__(tensor_transforms=tensor_transforms)
+        super().__init__(transforms=transforms)
 
         self._path = path
         self._device = device

--- a/src/eva/vision/models/networks/backbones/_utils.py
+++ b/src/eva/vision/models/networks/backbones/_utils.py
@@ -36,7 +36,7 @@ def load_hugingface_model(
 
     return models.HuggingFaceModel(
         model_name_or_path=model_name,
-        tensor_transforms=tensor_transforms,
+        transforms=tensor_transforms,
         model_kwargs=model_kwargs,
     )
 

--- a/src/eva/vision/models/networks/backbones/pathology/bioptimus.py
+++ b/src/eva/vision/models/networks/backbones/pathology/bioptimus.py
@@ -72,7 +72,7 @@ def bioptimus_h0_mini(
             "mlp_layer": timm.layers.SwiGLUPacked,
             "act_layer": nn.SiLU,
         },
-        tensor_transforms=(
+        transforms=(
             transforms.ExtractCLSFeatures(include_patch_tokens=include_patch_tokens)
             if out_indices is None
             else None

--- a/src/eva/vision/models/networks/backbones/pathology/paige.py
+++ b/src/eva/vision/models/networks/backbones/pathology/paige.py
@@ -43,7 +43,7 @@ def paige_virchow2(
             "mlp_layer": timm.layers.SwiGLUPacked,
             "act_layer": nn.SiLU,
         },
-        tensor_transforms=(
+        transforms=(
             transforms.ExtractCLSFeatures(include_patch_tokens=include_patch_tokens)
             if out_indices is None
             else None

--- a/src/eva/vision/models/wrappers/from_registry.py
+++ b/src/eva/vision/models/wrappers/from_registry.py
@@ -2,13 +2,14 @@
 
 from typing import Any, Callable, Dict
 
+import torch
 from typing_extensions import override
 
-from eva.core.models import wrappers
+from eva.core.models.wrappers import base
 from eva.vision.models.networks.backbones import BackboneModelRegistry
 
 
-class ModelFromRegistry(wrappers.BaseModel):
+class ModelFromRegistry(base.BaseModel[torch.Tensor, torch.Tensor]):
     """Wrapper class for vision backbone models.
 
     This class can be used by load backbones available in eva's
@@ -21,7 +22,7 @@ class ModelFromRegistry(wrappers.BaseModel):
         model_name: str,
         model_kwargs: Dict[str, Any] | None = None,
         model_extra_kwargs: Dict[str, Any] | None = None,
-        tensor_transforms: Callable | None = None,
+        transforms: Callable | None = None,
     ) -> None:
         """Initializes the model.
 
@@ -29,10 +30,10 @@ class ModelFromRegistry(wrappers.BaseModel):
             model_name: The name of the model to load.
             model_kwargs: The arguments used for instantiating the model.
             model_extra_kwargs: Extra arguments used for instantiating the model.
-            tensor_transforms: The transforms to apply to the output tensor
+            transforms: The transforms to apply to the output tensor
                 produced by the model.
         """
-        super().__init__(tensor_transforms=tensor_transforms)
+        super().__init__(transforms=transforms)
 
         self._model_name = model_name
         self._model_kwargs = model_kwargs or {}

--- a/src/eva/vision/models/wrappers/from_timm.py
+++ b/src/eva/vision/models/wrappers/from_timm.py
@@ -4,12 +4,13 @@ from typing import Any, Callable, Dict, Tuple
 from urllib import parse
 
 import timm
+import torch
 from typing_extensions import override
 
-from eva.core.models import wrappers
+from eva.core.models.wrappers import base
 
 
-class TimmModel(wrappers.BaseModel):
+class TimmModel(base.BaseModel[torch.Tensor, torch.Tensor]):
     """Model wrapper for `timm` models.
 
     Note that only models with `forward_intermediates`
@@ -23,7 +24,7 @@ class TimmModel(wrappers.BaseModel):
         checkpoint_path: str = "",
         out_indices: int | Tuple[int, ...] | None = None,
         model_kwargs: Dict[str, Any] | None = None,
-        tensor_transforms: Callable | None = None,
+        transforms: Callable | None = None,
     ) -> None:
         """Initializes the encoder.
 
@@ -34,10 +35,10 @@ class TimmModel(wrappers.BaseModel):
             out_indices: Returns last n blocks if `int`, all if `None`, select
                 matching indices if sequence.
             model_kwargs: Extra model arguments.
-            tensor_transforms: The transforms to apply to the output tensor
+            transforms: The transforms to apply to the output tensor
                 produced by the model.
         """
-        super().__init__(tensor_transforms=tensor_transforms)
+        super().__init__(transforms=transforms)
 
         self._model_name = model_name
         self._pretrained = pretrained


### PR DESCRIPTION
Not all models will use tensors as input & output. E.g. models from other modalities such as `language` for instance would use `str` (prompt input -> generated text output) or `list[str]` (batch of input prompts).

Given that `BaseModel` is part of `eva.core`, ideally it should support multiple modalities, which this PR enables through generic type hints for the inputs & outputs of the forward pass.


Example model wrapper class definitions:

```python
class YourVisionModel(BaseModel[torch.Tensor, torch.Tensor]):
    ... 

class YourLanguageModel(BaseModel[list[str], list[str]]):
    ...


```