### PR TITLE
Refactor `Registry` class and move to `eva.core`

### DIFF
--- a/docs/user-guide/advanced/model_registry.md
+++ b/docs/user-guide/advanced/model_registry.md
@@ -21,7 +21,7 @@ A model can then be loaded and instantiated like this:
 import torch
 from eva.vision.models.networks.backbones.registry import backbone_registry
 
-model = backbone_registry.get("universal/vit_small_patch16_224_random")(out_indices=2)
+model = backbone_registry.get("universal/vit_small_patch16_224_random")()
 output = model(torch.randn(1, 3, 224, 224))
 print(output.shape)
 # console output:
@@ -69,6 +69,6 @@ If you want to add a new FM backbone to *eva*'s registry, you'll need to follow 
 
 1. Implement a Python function that returns your model as a `torch.nn.Module`. If it's not a native PyTorch model, or if you have made the model already available in public hubs such as torch.hub or huggingface, our [model wrapper](./model_wrappers.md) classes might come in handy.
 
-2. Add your model function to `eva.vision.models.networks.backbones` together with a `@register_model("your_model_name")` decorator. Then add an import statement to the `__init__` file of the corresponding module.
+2. Add your model function to `eva.vision.models.networks.backbones` together with a `@backbone_registry.register("your_model_name")` decorator. Then add an import statement to the `__init__` file of the corresponding module.
 
 3. Open a PR 🚀

--- a/docs/user-guide/advanced/model_registry.md
+++ b/docs/user-guide/advanced/model_registry.md
@@ -4,9 +4,9 @@
 ## Loading models through the Python API
 The available models can be listed as follows after installing the *eva* package:
 ```python
-from eva.vision.models.networks.backbones import BackboneModelRegistry
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
-models = BackboneModelRegistry.list_models()
+models = backbone_registry.entries()
 print(models)
 ```
 
@@ -19,12 +19,9 @@ A model can then be loaded and instantiated like this:
 
 ```python
 import torch
-from eva.vision.models.networks.backbones import BackboneModelRegistry
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
-model = BackboneModelRegistry.load_model(
-    model_name="universal/vit_small_patch16_224_random",
-     **{"out_indices": 2}
-)
+model = backbone_registry.get("universal/vit_small_patch16_224_random")(out_indices=2)
 output = model(torch.randn(1, 3, 224, 224))
 print(output.shape)
 # console output:
@@ -35,10 +32,7 @@ In the above example, we load a vit-s model initialized with random weights. The
 For segmentation tasks, we need to access not only the CLS embedding, but entire feature maps. This we can achieve by using the `out_indices` argument:
 
 ```python
-model = BackboneModelRegistry.load_model(
-    model_name="universal/vit_small_patch16_224_random",
-     **{"out_indices": 2}
-)
+model = backbone_registry.get("universal/vit_small_patch16_224_random")(out_indices=2)
 outputs = model(torch.randn(1, 3, 224, 224))
 for output in outputs:
     print(output.shape)
@@ -62,7 +56,7 @@ backbone:
       out_indices: ${oc.env:OUT_INDICES, 1}
 ```
 
-Note that `ModelFromRegistry` is a model wrapper class, which loads the models through `BackboneModelRegistry`.
+Note that `ModelFromRegistry` is a model wrapper class, which loads the models through `backbone_registry`.
 
 By using the `MODEL_NAME` environment variable, you can run an evaluation with a specific model from the registry, without modifying the default config files:
 ```bash

--- a/src/eva/core/utils/factory.py
+++ b/src/eva/core/utils/factory.py
@@ -1,0 +1,60 @@
+"""Model builder wrapper."""
+
+import inspect
+from typing import Any, Dict, Generic, Type, TypeVar
+
+from torch import nn
+from typing_extensions import override
+
+from eva.core.utils.registry import Registry, RegistryItem
+
+T = TypeVar("T")
+
+
+class Factory(Generic[T]):
+    """A base factory class for instantiating registry items of a specific type."""
+
+    def __new__(cls, registry: Registry, name: str, init_args: dict, expected_type: Type[T]) -> T:
+        """Creates the appropriate instance based on registry entry.
+
+        Args:
+            registry: The registry containing the items to instantiate.
+            name: Name of the registry item to instantiate.
+            init_args: The arguments to pass to the constructor of the registry item.
+            expected_type: The expected type of the instantiated object.
+        """
+        if name not in registry.entries():
+            raise ValueError(
+                f"Invalid name: {name}. Please choose one "
+                f"of the following: {registry.entries()}"
+            )
+
+        cls = registry.get(name)
+        filtered_kwargs = _filter_kwargs(cls, init_args)
+        instance = cls(**filtered_kwargs)
+
+        if not isinstance(instance, expected_type):
+            raise TypeError(f"Expected an instance of {expected_type}, but got {type(instance)}.")
+        return instance
+
+
+class ModuleFactory(Factory[nn.Module]):
+    """Factory class for instantiating nn.Module instances from a registry."""
+
+    @override
+    def __new__(cls, registry: Registry, name: str, init_args: dict) -> nn.Module:
+        return super().__new__(cls, registry, name, init_args, nn.Module)
+
+
+def _filter_kwargs(cls: RegistryItem, kwargs: dict) -> Dict[str, Any]:
+    """Filters the given keyword arguments to match the `__init__` signature of a given class.
+
+    Args:
+        cls: The class whose `__init__` signature should be used for filtering.
+        kwargs: The keyword arguments to filter.
+
+    Returns:
+        A dictionary containing only the valid keyword arguments that match
+        the class constructor's parameters.
+    """
+    return {k: v for k, v in kwargs.items() if k in inspect.signature(cls.__init__).parameters}

--- a/src/eva/core/utils/factory.py
+++ b/src/eva/core/utils/factory.py
@@ -1,4 +1,4 @@
-"""Model builder wrapper."""
+"""Factory classes."""
 
 import inspect
 from typing import Any, Dict, Generic, Type, TypeVar

--- a/src/eva/core/utils/registry.py
+++ b/src/eva/core/utils/registry.py
@@ -1,0 +1,42 @@
+"""Helper registration class."""
+
+from typing import Any, Callable, Dict, List, Type, Union
+
+RegistryItem = Union[Type[Any], Callable[..., Any]]
+
+
+class Registry:
+    """A registry to store and access classes and methods by a unique key."""
+
+    def __init__(self) -> None:
+        """Initializes the registry class."""
+        self._registry: Dict[str, RegistryItem] = {}
+
+    def register(self, key: str, /) -> Callable[[RegistryItem], RegistryItem]:
+        """A decorator to register a class or method with a unique key.
+
+        Args:
+            key: The key to register the class or method under.
+
+        Returns:
+            A decorator that registers the class or method in the registry.
+        """
+
+        def wrapper(obj: RegistryItem) -> RegistryItem:
+            if key in self.entries():
+                raise ValueError(f"Entry {key} is already registered.")
+
+            self._registry[key] = obj
+            return obj
+
+        return wrapper
+
+    def get(self, name: str) -> RegistryItem:
+        """Gets the class or method from the registry."""
+        if name not in self._registry:
+            raise ValueError(f"Item {name} not found in the registry.")
+        return self._registry[name]
+
+    def entries(self) -> List[str]:
+        """List all items in the registry."""
+        return list(self._registry.keys())

--- a/src/eva/core/utils/registry.py
+++ b/src/eva/core/utils/registry.py
@@ -1,4 +1,4 @@
-"""Helper registration class."""
+"""Registry for classes and methods."""
 
 from typing import Any, Callable, Dict, List, Type, Union
 

--- a/src/eva/vision/models/networks/backbones/__init__.py
+++ b/src/eva/vision/models/networks/backbones/__init__.py
@@ -1,13 +1,12 @@
 """Vision Model Backbones API."""
 
 from eva.vision.models.networks.backbones import pathology, radiology, timm, universal
-from eva.vision.models.networks.backbones.registry import BackboneModelRegistry, register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 __all__ = [
     "radiology",
     "pathology",
     "timm",
     "universal",
-    "BackboneModelRegistry",
-    "register_model",
+    "backbone_registry",
 ]

--- a/src/eva/vision/models/networks/backbones/pathology/bioptimus.py
+++ b/src/eva/vision/models/networks/backbones/pathology/bioptimus.py
@@ -8,10 +8,10 @@ from torch import nn
 from eva.core.models import transforms
 from eva.vision.models import wrappers
 from eva.vision.models.networks.backbones import _utils
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
-@register_model("pathology/bioptimus_h_optimus_0")
+@backbone_registry.register("pathology/bioptimus_h_optimus_0")
 def bioptimus_h_optimus_0(
     dynamic_img_size: bool = True,
     out_indices: int | Tuple[int, ...] | None = None,
@@ -39,7 +39,7 @@ def bioptimus_h_optimus_0(
     )
 
 
-@register_model("pathology/bioptimus_h0_mini")
+@backbone_registry.register("pathology/bioptimus_h0_mini")
 def bioptimus_h0_mini(
     dynamic_img_size: bool = True,
     out_indices: int | Tuple[int, ...] | None = None,

--- a/src/eva/vision/models/networks/backbones/pathology/gigapath.py
+++ b/src/eva/vision/models/networks/backbones/pathology/gigapath.py
@@ -5,10 +5,10 @@ from typing import Tuple
 import timm
 from torch import nn
 
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
-@register_model("pathology/prov_gigapath")
+@backbone_registry.register("pathology/prov_gigapath")
 def prov_gigapath(
     dynamic_img_size: bool = True,
     out_indices: int | Tuple[int, ...] | None = None,

--- a/src/eva/vision/models/networks/backbones/pathology/histai.py
+++ b/src/eva/vision/models/networks/backbones/pathology/histai.py
@@ -5,10 +5,10 @@ from typing import Tuple
 from torch import nn
 
 from eva.vision.models.networks.backbones import _utils
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
-@register_model("pathology/histai_hibou_b")
+@backbone_registry.register("pathology/histai_hibou_b")
 def histai_hibou_b(out_indices: int | Tuple[int, ...] | None = None) -> nn.Module:
     """Initializes the hibou-B pathology FM by hist.ai (https://huggingface.co/histai/hibou-B).
 
@@ -30,7 +30,7 @@ def histai_hibou_b(out_indices: int | Tuple[int, ...] | None = None) -> nn.Modul
     )
 
 
-@register_model("pathology/histai_hibou_l")
+@backbone_registry.register("pathology/histai_hibou_l")
 def histai_hibou_l(out_indices: int | Tuple[int, ...] | None = None) -> nn.Module:
     """Initializes the hibou-L pathology FM by hist.ai (https://huggingface.co/histai/hibou-L).
 

--- a/src/eva/vision/models/networks/backbones/pathology/hkust.py
+++ b/src/eva/vision/models/networks/backbones/pathology/hkust.py
@@ -7,10 +7,10 @@ import timm
 from torch import nn
 
 from eva.core.models.wrappers import _utils
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
-@register_model("pathology/hkust_gpfm")
+@backbone_registry.register("pathology/hkust_gpfm")
 def hkust_gpfm(
     dynamic_img_size: bool = True,
     out_indices: int | Tuple[int, ...] | None = None,

--- a/src/eva/vision/models/networks/backbones/pathology/kaiko.py
+++ b/src/eva/vision/models/networks/backbones/pathology/kaiko.py
@@ -6,10 +6,10 @@ import torch
 from torch import nn
 
 from eva.vision.models.networks.backbones import _utils
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
-@register_model("pathology/kaiko_midnight_12k")
+@backbone_registry.register("pathology/kaiko_midnight_12k")
 def kaiko_midnight_12k(out_indices: int | Tuple[int, ...] | None = None) -> nn.Module:
     """Initializes the Midnight-12k pathology FM by kaiko.ai.
 
@@ -26,7 +26,7 @@ def kaiko_midnight_12k(out_indices: int | Tuple[int, ...] | None = None) -> nn.M
     )
 
 
-@register_model("pathology/kaiko_vits16")
+@backbone_registry.register("pathology/kaiko_vits16")
 def kaiko_vits16(
     dynamic_img_size: bool = True, out_indices: int | Tuple[int, ...] | None = None
 ) -> nn.Module:
@@ -49,7 +49,7 @@ def kaiko_vits16(
     )
 
 
-@register_model("pathology/kaiko_vits8")
+@backbone_registry.register("pathology/kaiko_vits8")
 def kaiko_vits8(
     dynamic_img_size: bool = True, out_indices: int | Tuple[int, ...] | None = None
 ) -> nn.Module:
@@ -72,7 +72,7 @@ def kaiko_vits8(
     )
 
 
-@register_model("pathology/kaiko_vitb16")
+@backbone_registry.register("pathology/kaiko_vitb16")
 def kaiko_vitb16(
     dynamic_img_size: bool = True, out_indices: int | Tuple[int, ...] | None = None
 ) -> nn.Module:
@@ -95,7 +95,7 @@ def kaiko_vitb16(
     )
 
 
-@register_model("pathology/kaiko_vitb8")
+@backbone_registry.register("pathology/kaiko_vitb8")
 def kaiko_vitb8(
     dynamic_img_size: bool = True, out_indices: int | Tuple[int, ...] | None = None
 ) -> nn.Module:
@@ -118,7 +118,7 @@ def kaiko_vitb8(
     )
 
 
-@register_model("pathology/kaiko_vitl14")
+@backbone_registry.register("pathology/kaiko_vitl14")
 def kaiko_vitl14(
     dynamic_img_size: bool = True, out_indices: int | Tuple[int, ...] | None = None
 ) -> nn.Module:

--- a/src/eva/vision/models/networks/backbones/pathology/lunit.py
+++ b/src/eva/vision/models/networks/backbones/pathology/lunit.py
@@ -13,14 +13,14 @@ from typing import Tuple
 from torch import nn
 
 from eva.vision.models import wrappers
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 VITS_URL_PREFIX = (
     "https://github.com/lunit-io/benchmark-ssl-pathology/releases/download/pretrained-weights"
 )
 
 
-@register_model("pathology/lunit_vits16")
+@backbone_registry.register("pathology/lunit_vits16")
 def lunit_vits16(
     dynamic_img_size: bool = True, out_indices: int | Tuple[int, ...] | None = None
 ) -> nn.Module:
@@ -44,7 +44,7 @@ def lunit_vits16(
     )
 
 
-@register_model("pathology/lunit_vits8")
+@backbone_registry.register("pathology/lunit_vits8")
 def lunit_vits8(
     dynamic_img_size: bool = True, out_indices: int | Tuple[int, ...] | None = None
 ) -> nn.Module:

--- a/src/eva/vision/models/networks/backbones/pathology/mahmood.py
+++ b/src/eva/vision/models/networks/backbones/pathology/mahmood.py
@@ -8,10 +8,10 @@ from torch import nn
 
 from eva.vision.models import wrappers
 from eva.vision.models.networks.backbones import _utils
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
-@register_model("pathology/mahmood_uni")
+@backbone_registry.register("pathology/mahmood_uni")
 def mahmood_uni(
     dynamic_img_size: bool = True,
     out_indices: int | Tuple[int, ...] | None = None,
@@ -41,7 +41,7 @@ def mahmood_uni(
     )
 
 
-@register_model("pathology/mahmood_uni2_h")
+@backbone_registry.register("pathology/mahmood_uni2_h")
 def mahmood_uni2_h(
     dynamic_img_size: bool = True,
     out_indices: int | Tuple[int, ...] | None = None,

--- a/src/eva/vision/models/networks/backbones/pathology/owkin.py
+++ b/src/eva/vision/models/networks/backbones/pathology/owkin.py
@@ -5,10 +5,10 @@ from typing import Tuple
 from torch import nn
 
 from eva.vision.models.networks.backbones import _utils
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
-@register_model("pathology/owkin_phikon")
+@backbone_registry.register("pathology/owkin_phikon")
 def owkin_phikon(out_indices: int | Tuple[int, ...] | None = None) -> nn.Module:
     """Initializes the phikon pathology FM by owkin (https://huggingface.co/owkin/phikon).
 
@@ -22,7 +22,7 @@ def owkin_phikon(out_indices: int | Tuple[int, ...] | None = None) -> nn.Module:
     return _utils.load_hugingface_model(model_name="owkin/phikon", out_indices=out_indices)
 
 
-@register_model("pathology/owkin_phikon_v2")
+@backbone_registry.register("pathology/owkin_phikon_v2")
 def owkin_phikon_v2(out_indices: int | Tuple[int, ...] | None = None) -> nn.Module:
     """Initializes the phikon-v2 pathology FM by owkin (https://huggingface.co/owkin/phikon-v2).
 

--- a/src/eva/vision/models/networks/backbones/pathology/paige.py
+++ b/src/eva/vision/models/networks/backbones/pathology/paige.py
@@ -11,10 +11,10 @@ import torch.nn as nn
 from eva.core.models import transforms
 from eva.vision.models import wrappers
 from eva.vision.models.networks.backbones import _utils
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
-@register_model("pathology/paige_virchow2")
+@backbone_registry.register("pathology/paige_virchow2")
 def paige_virchow2(
     dynamic_img_size: bool = True,
     out_indices: int | Tuple[int, ...] | None = None,

--- a/src/eva/vision/models/networks/backbones/radiology/swin_unetr.py
+++ b/src/eva/vision/models/networks/backbones/radiology/swin_unetr.py
@@ -9,10 +9,10 @@ from monai.networks.nets import swin_unetr
 from monai.utils import misc
 from torch import nn
 
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
-@register_model("radiology/swin_unetr_encoder")
+@backbone_registry.register("radiology/swin_unetr_encoder")
 class SwinUNETREncoder(nn.Module):
     """Swin transformer encoder based on UNETR [0].
 

--- a/src/eva/vision/models/networks/backbones/radiology/voco.py
+++ b/src/eva/vision/models/networks/backbones/radiology/voco.py
@@ -4,7 +4,7 @@ from typing_extensions import override
 
 from eva.core.models.wrappers import _utils
 from eva.vision.models.networks.backbones.radiology import swin_unetr
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
 class _VoCo(swin_unetr.SwinUNETREncoder):
@@ -39,7 +39,7 @@ class _VoCo(swin_unetr.SwinUNETREncoder):
         self.load_state_dict(state_dict)
 
 
-@register_model("radiology/voco_b")
+@backbone_registry.register("radiology/voco_b")
 class VoCoB(_VoCo):
     """VoCo Self-supervised pre-trained B model."""
 
@@ -51,7 +51,7 @@ class VoCoB(_VoCo):
         super().__init__(feature_size=48, out_indices=out_indices)
 
 
-@register_model("radiology/voco_l")
+@backbone_registry.register("radiology/voco_l")
 class VoCoL(_VoCo):
     """VoCo Self-supervised pre-trained L model."""
 
@@ -63,7 +63,7 @@ class VoCoL(_VoCo):
         super().__init__(feature_size=96, out_indices=out_indices)
 
 
-@register_model("radiology/voco_h")
+@backbone_registry.register("radiology/voco_h")
 class VoCoH(_VoCo):
     """VoCo Self-supervised pre-trained H model."""
 

--- a/src/eva/vision/models/networks/backbones/radiology/voco.py
+++ b/src/eva/vision/models/networks/backbones/radiology/voco.py
@@ -7,7 +7,7 @@ from eva.vision.models.networks.backbones.radiology import swin_unetr
 from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
-class _VoCo(swin_unetr.SwinUNETREncoder):
+class _VoCo(swin_unetr.SwinUNETREncoder):  # type: ignore
     """Base class for the VoCo self-supervised encoders."""
 
     _checkpoint: str

--- a/src/eva/vision/models/networks/backbones/registry.py
+++ b/src/eva/vision/models/networks/backbones/registry.py
@@ -1,47 +1,5 @@
 """Backbone Model Registry."""
 
-from typing import Any, Callable, Dict, List
+from eva.core.utils.registry import Registry
 
-import torch.nn as nn
-
-
-class BackboneModelRegistry:
-    """A model registry for accessing backbone models by name."""
-
-    _registry: Dict[str, Callable[..., nn.Module]] = {}
-
-    @classmethod
-    def register(cls, name: str) -> Callable:
-        """Decorator to register a new model."""
-
-        def decorator(model_fn: Callable[..., nn.Module]) -> Callable[..., nn.Module]:
-            if name in cls._registry:
-                raise ValueError(f"Model {name} is already registered.")
-            cls._registry[name] = model_fn
-            return model_fn
-
-        return decorator
-
-    @classmethod
-    def get(cls, model_name: str) -> Callable[..., nn.Module]:
-        """Gets a model function from the registry."""
-        if model_name not in cls._registry:
-            raise ValueError(f"Model {model_name} not found in the registry.")
-        return cls._registry[model_name]
-
-    @classmethod
-    def load_model(cls, model_name: str, model_kwargs: Dict[str, Any] | None = None) -> nn.Module:
-        """Loads & initializes a model class from the registry."""
-        model_fn = cls.get(model_name)
-        return model_fn(**(model_kwargs or {}))
-
-    @classmethod
-    def list_models(cls) -> List[str]:
-        """List all models in the registry."""
-        register_models = [name for name in cls._registry.keys() if not name.startswith("timm")]
-        return register_models + ["timm/<model_name>"]
-
-
-def register_model(name: str) -> Callable:
-    """Simple decorator to register a model."""
-    return BackboneModelRegistry.register(name)
+backbone_registry = Registry()

--- a/src/eva/vision/models/networks/backbones/timm/backbones.py
+++ b/src/eva/vision/models/networks/backbones/timm/backbones.py
@@ -8,7 +8,7 @@ from loguru import logger
 from torch import nn
 
 from eva.vision.models import wrappers
-from eva.vision.models.networks.backbones.registry import BackboneModelRegistry
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
 def timm_model(
@@ -46,7 +46,7 @@ def timm_model(
     )
 
 
-BackboneModelRegistry._registry.update(
+backbone_registry._registry.update(
     {
         f"timm/{model_name}": functools.partial(timm_model, model_name=model_name)
         for model_name in timm.list_models()

--- a/src/eva/vision/models/networks/backbones/universal/vit.py
+++ b/src/eva/vision/models/networks/backbones/universal/vit.py
@@ -5,10 +5,10 @@ from typing import Tuple
 import timm
 from torch import nn
 
-from eva.vision.models.networks.backbones.registry import register_model
+from eva.vision.models.networks.backbones.registry import backbone_registry
 
 
-@register_model("universal/vit_small_patch16_224_random")
+@backbone_registry.register("universal/vit_small_patch16_224_random")
 def vit_small_patch16_224_random(
     dynamic_img_size: bool = True, out_indices: int | Tuple[int, ...] | None = None
 ) -> nn.Module:
@@ -31,7 +31,7 @@ def vit_small_patch16_224_random(
     )
 
 
-@register_model("universal/vit_small_patch16_224_dino")
+@backbone_registry.register("universal/vit_small_patch16_224_dino")
 def vit_small_patch16_224_dino(
     dynamic_img_size: bool = True, out_indices: int | Tuple[int, ...] | None = None
 ) -> nn.Module:
@@ -54,7 +54,7 @@ def vit_small_patch16_224_dino(
     )
 
 
-@register_model("universal/vit_small_patch16_224_dino_1chan")
+@backbone_registry.register("universal/vit_small_patch16_224_dino_1chan")
 def vit_small_patch16_224_dino_1chan(
     dynamic_img_size: bool = True, out_indices: int | Tuple[int, ...] | None = None
 ) -> nn.Module:
@@ -79,7 +79,7 @@ def vit_small_patch16_224_dino_1chan(
     )
 
 
-@register_model("universal/vit_base_patch16_224_dino_1chan")
+@backbone_registry.register("universal/vit_base_patch16_224_dino_1chan")
 def vit_base_patch16_224_dino_1chan(
     dynamic_img_size: bool = True, out_indices: int | Tuple[int, ...] | None = None
 ) -> nn.Module:

--- a/src/eva/vision/models/wrappers/from_registry.py
+++ b/src/eva/vision/models/wrappers/from_registry.py
@@ -6,7 +6,8 @@ import torch
 from typing_extensions import override
 
 from eva.core.models.wrappers import base
-from eva.vision.models.networks.backbones import BackboneModelRegistry
+from eva.core.utils import factory
+from eva.vision.models.networks.backbones import backbone_registry
 
 
 class ModelFromRegistry(base.BaseModel[torch.Tensor, torch.Tensor]):
@@ -14,7 +15,7 @@ class ModelFromRegistry(base.BaseModel[torch.Tensor, torch.Tensor]):
 
     This class can be used by load backbones available in eva's
     model registry by name. New backbones can be registered by using
-    the `@register_model(model_name)` decorator.
+    the `@backbone_registry.register(model_name)` decorator.
     """
 
     def __init__(
@@ -43,7 +44,10 @@ class ModelFromRegistry(base.BaseModel[torch.Tensor, torch.Tensor]):
 
     @override
     def load_model(self) -> None:
-        self._model = BackboneModelRegistry.load_model(
-            self._model_name, self._model_kwargs | self._model_extra_kwargs
+        self._model = factory.ModuleFactory(
+            registry=backbone_registry,
+            name=self._model_name,
+            init_args=self._model_kwargs | self._model_extra_kwargs,
         )
+
         ModelFromRegistry.__name__ = self._model_name

--- a/tests/eva/core/utils/test_factory.py
+++ b/tests/eva/core/utils/test_factory.py
@@ -1,0 +1,85 @@
+"""Tests for the factory module."""
+
+import pytest
+from torch import nn
+
+from eva.core.utils import factory
+from eva.core.utils.registry import Registry
+
+
+class MockModel(nn.Module):
+    def __init__(self, param1: int = 1, param2: str = "default"):
+        super().__init__()
+        self.param1 = param1
+        self.param2 = param2
+
+
+class MockClass:
+    def __init__(self, arg1: int, arg2: str = "test"):
+        self.arg1 = arg1
+        self.arg2 = arg2
+
+
+def _mock_function(x: int, y: str = "default") -> str:
+    return f"{x}_{y}"
+
+
+@pytest.fixture
+def test_registry():
+    """Fixture to create a test registry with mock items."""
+    registry = Registry()
+    registry.register("mock_model")(MockModel)
+    registry.register("mock_class")(MockClass)
+    registry.register("mock_function")(_mock_function)
+    return registry
+
+
+def test_factory_valid_instantiation(test_registry):
+    """Test Factory creates valid instances."""
+    instance = factory.Factory(test_registry, "mock_class", {"arg1": 42}, MockClass)
+    assert isinstance(instance, MockClass)
+    assert instance.arg1 == 42
+    assert instance.arg2 == "test"
+
+
+def test_factory_with_filtered_kwargs(test_registry):
+    """Test Factory filters kwargs correctly."""
+    init_args = {"arg1": 100, "arg2": "custom", "invalid_arg": "ignored"}
+    instance = factory.Factory(test_registry, "mock_class", init_args, MockClass)
+    assert instance.arg1 == 100
+    assert instance.arg2 == "custom"
+
+
+def test_factory_invalid_name(test_registry):
+    """Test Factory raises ValueError for invalid name."""
+    with pytest.raises(ValueError, match="Invalid name: nonexistent"):
+        factory.Factory(test_registry, "nonexistent", {}, MockClass)
+
+
+def test_factory_type_mismatch(test_registry):
+    """Test Factory raises TypeError for type mismatch."""
+    with pytest.raises(TypeError, match="Expected an instance of"):
+        factory.Factory(test_registry, "mock_function", {"x": 1}, MockClass)
+
+
+def test_module_factory_valid_instantiation(test_registry):
+    """Test ModuleFactory creates valid nn.Module instances."""
+    instance = factory.ModuleFactory(test_registry, "mock_model", {"param1": 5})
+    assert isinstance(instance, nn.Module)
+    assert isinstance(instance, MockModel)
+    assert instance.param1 == 5
+    assert instance.param2 == "default"
+
+
+def test_filter_kwargs_class():
+    """Test _filter_kwargs with class constructor."""
+    kwargs = {"arg1": 42, "arg2": "test", "invalid": "ignored"}
+    filtered = factory._filter_kwargs(MockClass, kwargs)
+    assert filtered == {"arg1": 42, "arg2": "test"}
+
+
+def test_filter_kwargs_function():
+    """Test _filter_kwargs with function."""
+    kwargs = {"x": 1, "y": "hello", "z": "ignored"}
+    filtered = factory._filter_kwargs(_mock_function, kwargs)
+    assert filtered == {"x": 1, "y": "hello"}

--- a/tests/eva/core/utils/test_factory.py
+++ b/tests/eva/core/utils/test_factory.py
@@ -7,14 +7,14 @@ from eva.core.utils import factory
 from eva.core.utils.registry import Registry
 
 
-class MockModel(nn.Module):
+class _MockModel(nn.Module):
     def __init__(self, param1: int = 1, param2: str = "default"):
         super().__init__()
         self.param1 = param1
         self.param2 = param2
 
 
-class MockClass:
+class _MockClass:
     def __init__(self, arg1: int, arg2: str = "test"):
         self.arg1 = arg1
         self.arg2 = arg2
@@ -28,16 +28,16 @@ def _mock_function(x: int, y: str = "default") -> str:
 def test_registry():
     """Fixture to create a test registry with mock items."""
     registry = Registry()
-    registry.register("mock_model")(MockModel)
-    registry.register("mock_class")(MockClass)
+    registry.register("mock_model")(_MockModel)
+    registry.register("mock_class")(_MockClass)
     registry.register("mock_function")(_mock_function)
     return registry
 
 
 def test_factory_valid_instantiation(test_registry):
     """Test Factory creates valid instances."""
-    instance = factory.Factory(test_registry, "mock_class", {"arg1": 42}, MockClass)
-    assert isinstance(instance, MockClass)
+    instance = factory.Factory(test_registry, "mock_class", {"arg1": 42}, _MockClass)
+    assert isinstance(instance, _MockClass)
     assert instance.arg1 == 42
     assert instance.arg2 == "test"
 
@@ -45,7 +45,7 @@ def test_factory_valid_instantiation(test_registry):
 def test_factory_with_filtered_kwargs(test_registry):
     """Test Factory filters kwargs correctly."""
     init_args = {"arg1": 100, "arg2": "custom", "invalid_arg": "ignored"}
-    instance = factory.Factory(test_registry, "mock_class", init_args, MockClass)
+    instance = factory.Factory(test_registry, "mock_class", init_args, _MockClass)
     assert instance.arg1 == 100
     assert instance.arg2 == "custom"
 
@@ -53,20 +53,20 @@ def test_factory_with_filtered_kwargs(test_registry):
 def test_factory_invalid_name(test_registry):
     """Test Factory raises ValueError for invalid name."""
     with pytest.raises(ValueError, match="Invalid name: nonexistent"):
-        factory.Factory(test_registry, "nonexistent", {}, MockClass)
+        factory.Factory(test_registry, "nonexistent", {}, _MockClass)
 
 
 def test_factory_type_mismatch(test_registry):
     """Test Factory raises TypeError for type mismatch."""
     with pytest.raises(TypeError, match="Expected an instance of"):
-        factory.Factory(test_registry, "mock_function", {"x": 1}, MockClass)
+        factory.Factory(test_registry, "mock_function", {"x": 1}, _MockClass)
 
 
 def test_module_factory_valid_instantiation(test_registry):
     """Test ModuleFactory creates valid nn.Module instances."""
     instance = factory.ModuleFactory(test_registry, "mock_model", {"param1": 5})
     assert isinstance(instance, nn.Module)
-    assert isinstance(instance, MockModel)
+    assert isinstance(instance, _MockModel)
     assert instance.param1 == 5
     assert instance.param2 == "default"
 
@@ -74,7 +74,7 @@ def test_module_factory_valid_instantiation(test_registry):
 def test_filter_kwargs_class():
     """Test _filter_kwargs with class constructor."""
     kwargs = {"arg1": 42, "arg2": "test", "invalid": "ignored"}
-    filtered = factory._filter_kwargs(MockClass, kwargs)
+    filtered = factory._filter_kwargs(_MockClass, kwargs)
     assert filtered == {"arg1": 42, "arg2": "test"}
 
 

--- a/tests/eva/vision/models/networks/backbones/test_registry.py
+++ b/tests/eva/vision/models/networks/backbones/test_registry.py
@@ -5,26 +5,19 @@ from typing import Callable
 import pytest
 import torch.nn as nn
 
-from eva.vision.models.networks.backbones import BackboneModelRegistry, register_model
+from eva.vision.models.networks.backbones import backbone_registry
 
 
 @pytest.mark.parametrize("model_name", ["universal/vit_small_patch16_224_random"])
 def test_get_model(model_name: str):
     """Test getting a model function from the registry."""
-    model_fn = BackboneModelRegistry.get(model_name)
+    model_fn = backbone_registry.get(model_name)
     assert isinstance(model_fn, Callable)
 
 
-@pytest.mark.parametrize("model_name", ["universal/vit_small_patch16_224_random"])
-def test_load_model(model_name: str):
-    """Test loading an instantiated model from the registry."""
-    model = BackboneModelRegistry.load_model(model_name)
-    assert isinstance(model, nn.Module)
-
-
-def test_list_models():
-    """Test listing all models in the registry."""
-    models = BackboneModelRegistry.list_models()
+def test_list_entries():
+    """Test listing all entries in the registry."""
+    models = backbone_registry.entries()
     assert isinstance(models, list)
     assert len(models) > 0
 
@@ -32,14 +25,14 @@ def test_list_models():
 def test_register_model():
     """Test registering and loading a model."""
     model_name = "test_model_1"
-    with pytest.raises(ValueError, match=f"Model {model_name} not found in the registry."):
-        BackboneModelRegistry.get(model_name)
+    with pytest.raises(ValueError, match=f"Item {model_name} not found in the registry."):
+        backbone_registry.get(model_name)
 
-    @register_model(model_name)
+    @backbone_registry.register(model_name)
     def dummy_model_fn():
         return DummyModel()
 
-    model_fn = BackboneModelRegistry.get(model_name)
+    model_fn = backbone_registry.get(model_name)
     assert isinstance(model_fn, Callable)
     assert isinstance(model_fn(), DummyModel)
 
@@ -48,13 +41,13 @@ def test_register_model_duplicate():
     """Test if registry raises error when the model name already exists."""
     model_name = "test_model_2"
 
-    @register_model(model_name)
+    @backbone_registry.register(model_name)
     def dummy_model_fn():
         return DummyModel()
 
-    with pytest.raises(ValueError, match=f"Model {model_name} is already registered."):
+    with pytest.raises(ValueError, match=f"Entry {model_name} is already registered."):
 
-        @register_model(model_name)
+        @backbone_registry.register(model_name)
         def dummy_model_fn():
             return DummyModel()
 


### PR DESCRIPTION
- Refactors the `BackboneModelRegistry` class into a more generic `Registry` class and moves the logic from `eva.vision` to `eva.core`
- The new `Registry` class now supports both classes & methods (previously only methods were supported)
- Adds a `Factory` class to do the class instantiation there instead of in the registry

With this change we can now easily add registries for different things (e.g. data transforms):

```python

from eva.core.utils.registry import Registry

transforms_registry = Registry()

```