### PR TITLE
Change datasets requirement to `datasets<4.0.0,>=2.19.0`

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "all", "dev", "docs", "language", "lint", "test", "typecheck", "vision"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:6879103076a2f5e47d05fbd30419dd13e121afb47b277cc2e2ffdff587ad0a06"
+content_hash = "sha256:8b15139ebec0535e860fdedb3fdb86c4ee468fc8d661bcc9b34e7688d2673a2c"
 
 [[metadata.targets]]
 requires_python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ vision = [
     "einops>=0.8.1",
 ]
 language = [
-    "datasets>=3.2.0",
+    "datasets<4.0.0,>=2.19.0",
     "litellm>=1.61.8",
 ]
 all = [
@@ -89,7 +89,7 @@ all = [
     "scipy>=1.14.0",
     "monai>=1.3.2",
     "einops>=0.8.1",
-    "datasets>=3.2.0",
+    "datasets<4.0.0,>=2.19.0",
     "litellm>=1.61.8",
 ]
 


### PR DESCRIPTION
Previous requirement was too tight as `language` pipeline also seems to work with older versions.