### PR TITLE
Fix wandb rename run issue with `wandb>=0.21.0`

### DIFF
--- a/src/eva/core/loggers/utils/wandb.py
+++ b/src/eva/core/loggers/utils/wandb.py
@@ -5,6 +5,8 @@ from typing import Any, Dict
 
 from loguru import logger
 
+from eva.core.utils import requirements
+
 
 def rename_active_run(name: str) -> None:
     """Renames the current run."""
@@ -12,7 +14,8 @@ def rename_active_run(name: str) -> None:
 
     if wandb.run:
         wandb.run.name = name
-        wandb.run.save()
+        if requirements.below("wandb", "0.21.0"):
+            wandb.run.save()
     else:
         logger.warning("No active wandb run found that could be renamed.")
 

--- a/src/eva/core/utils/requirements.py
+++ b/src/eva/core/utils/requirements.py
@@ -3,10 +3,58 @@
 import importlib
 from typing import Dict
 
-from packaging import version
+import packaging.version
 
 
-def check_dependencies(requirements: Dict[str, str]) -> None:
+def fetch_version(name: str) -> str | None:
+    """Fetch the installed version of a package.
+
+    Args:
+        name: The name of the package.
+
+    Returns:
+        A string representing the installed version of the package, or None if not found.
+    """
+    try:
+        module = importlib.import_module(name)
+        return getattr(module, "__version__", None)
+    except ImportError:
+        return None
+
+
+def below(name: str, version: str) -> bool:
+    """Check if the installed version of a package is below a certain version.
+
+    Args:
+        name: The name of the package.
+        version: The version to compare against.
+
+    Returns:
+        True if the installed version is below the specified version, False otherwise.
+    """
+    actual = fetch_version(name)
+    if actual:
+        return packaging.version.parse(actual) < packaging.version.parse(version)
+    return False
+
+
+def above_or_equal(name: str, version: str) -> bool:
+    """Check if the installed version of a package is above a certain version.
+
+    Args:
+        name: The name of the package.
+        version: The version to compare against.
+
+    Returns:
+        True if the installed version is above the specified version, False otherwise.
+    """
+    actual = fetch_version(name)
+    if actual:
+        return packaging.version.parse(actual) >= packaging.version.parse(version)
+    return False
+
+
+def check_min_versions(requirements: Dict[str, str]) -> None:
     """Check installed package versions against requirements dict.
 
     Args:
@@ -17,10 +65,8 @@ def check_dependencies(requirements: Dict[str, str]) -> None:
         ImportError: If any package does not meet the minimum required version.
     """
     for package, min_version in requirements.items():
-        module = importlib.import_module(package)
-        actual = getattr(module, "__version__", None)
-        if actual and not (version.parse(actual) >= version.parse(min_version)):
+        if below(package, min_version):
             raise ImportError(
-                f"Package '{package}' version {actual} does not meet "
+                f"Package '{package}' version {fetch_version(package)} does not meet "
                 f"the minimum required version {min_version}."
             )

--- a/src/eva/multimodal/models/networks/others.py
+++ b/src/eva/multimodal/models/networks/others.py
@@ -20,7 +20,7 @@ class PathoR13b(wrappers.HuggingFaceModel):
         attn_implementation: str = "flash_attention_2",
     ):
         """Initialize the Patho-R1-3B model."""
-        requirements.check_dependencies(requirements={"torch": "2.5.1", "torchvision": "0.20.1"})
+        requirements.check_min_versions(requirements={"torch": "2.5.1", "torchvision": "0.20.1"})
 
         if not os.getenv("HF_TOKEN"):
             raise ValueError("HF_TOKEN env variable must be set.")

--- a/src/eva/vision/data/datasets/segmentation/btcv.py
+++ b/src/eva/vision/data/datasets/segmentation/btcv.py
@@ -106,7 +106,7 @@ class BTCV(VisionDataset[eva_tv_tensors.Volume, tv_tensors.Mask]):
 
     @override
     def validate(self) -> None:
-        requirements.check_dependencies(requirements={"torch": "2.5.1", "torchvision": "0.20.1"})
+        requirements.check_min_versions(requirements={"torch": "2.5.1", "torchvision": "0.20.1"})
 
         def _valid_sample(index: int) -> bool:
             """Indicates if the sample files exist and are reachable."""

--- a/src/eva/vision/data/datasets/segmentation/lits17.py
+++ b/src/eva/vision/data/datasets/segmentation/lits17.py
@@ -123,7 +123,7 @@ class LiTS17(VisionDataset[eva_tv_tensors.Volume, tv_tensors.Mask]):
 
     @override
     def validate(self) -> None:
-        requirements.check_dependencies(requirements={"torch": "2.5.1", "torchvision": "0.20.1"})
+        requirements.check_min_versions(requirements={"torch": "2.5.1", "torchvision": "0.20.1"})
 
         def _valid_sample(index: int) -> bool:
             """Indicates if the sample files exist and are reachable."""

--- a/src/eva/vision/data/datasets/segmentation/msd_task7_pancreas.py
+++ b/src/eva/vision/data/datasets/segmentation/msd_task7_pancreas.py
@@ -95,7 +95,7 @@ class MSDTask7Pancreas(VisionDataset[eva_tv_tensors.Volume, tv_tensors.Mask]):
 
     @override
     def validate(self) -> None:
-        requirements.check_dependencies(requirements={"torch": "2.5.1", "torchvision": "0.20.1"})
+        requirements.check_min_versions(requirements={"torch": "2.5.1", "torchvision": "0.20.1"})
 
         def _valid_sample(index: int) -> bool:
             """Indicates if the sample files exist and are reachable."""

--- a/tests/eva/core/utils/test_requirements.py
+++ b/tests/eva/core/utils/test_requirements.py
@@ -1,0 +1,131 @@
+"""Unit tests for requirements utility functions."""
+
+import importlib
+from unittest import mock
+
+import pytest
+
+from eva.core.utils import requirements
+
+
+class MockModule:
+    """Mock module for testing."""
+
+    def __init__(self, version: str | None = None):
+        """Creates an instance."""
+        if version:
+            self.__version__ = version
+
+
+@pytest.mark.parametrize(
+    "module_fixture,expected",
+    [
+        (MockModule(version="1.2.3"), "1.2.3"),
+        (MockModule(), None),
+    ],
+)
+def test_fetch_version_with_module(module_fixture, expected):
+    """Test fetch_version with different module configurations."""
+    with mock.patch.object(importlib, "import_module", return_value=module_fixture):
+        result = requirements.fetch_version("test_module")
+        assert result == expected
+
+
+def test_fetch_version_import_error():
+    """Test fetch_version when module cannot be imported."""
+    with mock.patch.object(importlib, "import_module", side_effect=ImportError):
+        result = requirements.fetch_version("non_existent_module")
+        assert result is None
+
+
+@pytest.mark.parametrize(
+    "installed,required,expected",
+    [
+        ("1.0.0", "2.0.0", True),  # lower version
+        ("2.0.0", "1.0.0", False),  # higher version
+        ("1.0.0", "1.0.0", False),  # equal version
+        (None, "1.0.0", False),  # no version
+    ],
+)
+def test_below(installed, required, expected):
+    """Test below function with various version scenarios."""
+    with mock.patch.object(requirements, "fetch_version", return_value=installed):
+        assert requirements.below("test_module", required) == expected
+
+
+@pytest.mark.parametrize(
+    "installed,required,expected",
+    [
+        ("2.0.0", "1.0.0", True),  # higher version
+        ("1.0.0", "2.0.0", False),  # lower version
+        ("1.0.0", "1.0.0", True),  # equal version
+        (None, "1.0.0", False),  # no version
+    ],
+)
+def test_above_or_equal(installed, required, expected):
+    """Test above_or_equal function with various version scenarios."""
+    with mock.patch.object(requirements, "fetch_version", return_value=installed):
+        assert requirements.above_or_equal("test_module", required) == expected
+
+
+def test_check_min_versions_all_satisfied():
+    """Test check_min_versions when all requirements are satisfied."""
+    reqs = {
+        "package1": "1.0.0",
+        "package2": "2.0.0",
+    }
+
+    with mock.patch.object(requirements, "fetch_version") as mock_fetch:
+        mock_fetch.side_effect = ["1.5.0", "2.1.0"]
+        with mock.patch.object(requirements, "below", return_value=False):
+            requirements.check_min_versions(reqs)
+
+
+def test_check_min_versions_not_satisfied():
+    """Test check_min_versions when a requirement is not satisfied."""
+    reqs = {
+        "package1": "2.0.0",
+        "package2": "3.0.0",
+    }
+
+    with mock.patch.object(requirements, "fetch_version", return_value="1.0.0"):
+        with mock.patch.object(requirements, "below", return_value=True):
+            with pytest.raises(ImportError) as exc_info:
+                requirements.check_min_versions(reqs)
+
+            assert "package1" in str(exc_info.value)
+            assert "1.0.0" in str(exc_info.value)
+            assert "2.0.0" in str(exc_info.value)
+
+
+def test_check_min_versions_empty():
+    """Test check_min_versions with empty requirements."""
+    requirements.check_min_versions({})
+
+
+@pytest.mark.parametrize(
+    "installed,required,below_expected,above_expected",
+    [
+        ("1.0.0.dev0", "1.0.0", True, False),  # dev version
+        ("1.0.0rc1", "1.0.0", True, False),  # rc version
+        ("1.2.3.post1", "1.2.4", True, None),  # post version - below
+    ],
+)
+def test_version_comparison_special_versions(installed, required, below_expected, above_expected):
+    """Test version comparison with special version formats."""
+    with mock.patch.object(requirements, "fetch_version", return_value=installed):
+        assert requirements.below("test_module", required) == below_expected
+        if above_expected is not None:
+            assert requirements.above_or_equal("test_module", required) == above_expected
+
+
+@pytest.mark.parametrize(
+    "installed,required,expected",
+    [
+        ("1.2.3.post1", "1.2.3", True),  # post version - above_or_equal
+    ],
+)
+def test_above_or_equal_special_versions(installed, required, expected):
+    """Test above_or_equal with special version formats."""
+    with mock.patch.object(requirements, "fetch_version", return_value=installed):
+        assert requirements.above_or_equal("test_module", required) == expected


### PR DESCRIPTION
Closes #876


W&B now automatically syncs metadata periodically. In practice, assigning to wandb.run.name is enough in v0.21+ and an explicit `run.save()` call is not required anymore.