### PR TITLE
Make processor source configurable through `processor_kwargs` in `HuggingFaceModel`

### DIFF
--- a/src/eva/multimodal/models/wrappers/huggingface.py
+++ b/src/eva/multimodal/models/wrappers/huggingface.py
@@ -147,8 +147,14 @@ class HuggingFaceModel(base.VisionLanguageModel):
 
     def load_processor(self) -> Callable:
         """Initialize the processor."""
+        if "model_name_or_path" in self.processor_kwargs:
+            model_name_or_path = self.processor_kwargs.pop("model_name_or_path")
+        else:
+            model_name_or_path = self.model_name_or_path
+        logger.info(f"Loading processor from: {model_name_or_path}")
+
         return transformers.AutoProcessor.from_pretrained(
-            self.model_name_or_path,
+            model_name_or_path,
             **self.processor_kwargs,
         )
 

--- a/src/eva/multimodal/models/wrappers/huggingface.py
+++ b/src/eva/multimodal/models/wrappers/huggingface.py
@@ -147,10 +147,10 @@ class HuggingFaceModel(base.VisionLanguageModel):
 
     def load_processor(self) -> Callable:
         """Initialize the processor."""
-        if "model_name_or_path" not in self.processor_kwargs:
-            self.processor_kwargs["model_name_or_path"] = self.model_name_or_path
-
-        return transformers.AutoProcessor.from_pretrained(**self.processor_kwargs)
+        return transformers.AutoProcessor.from_pretrained(
+            self.processor_kwargs.pop("model_name_or_path", self.model_name_or_path),
+            **self.processor_kwargs,
+        )
 
     def _unpack_batch(self, batch: TextImageBatch | TextBatch) -> tuple:
         if isinstance(batch, TextImageBatch):

--- a/src/eva/multimodal/models/wrappers/huggingface.py
+++ b/src/eva/multimodal/models/wrappers/huggingface.py
@@ -147,16 +147,10 @@ class HuggingFaceModel(base.VisionLanguageModel):
 
     def load_processor(self) -> Callable:
         """Initialize the processor."""
-        if "model_name_or_path" in self.processor_kwargs:
-            model_name_or_path = self.processor_kwargs.pop("model_name_or_path")
-        else:
-            model_name_or_path = self.model_name_or_path
-        logger.info(f"Loading processor from: {model_name_or_path}")
+        if "model_name_or_path" not in self.processor_kwargs:
+            self.processor_kwargs["model_name_or_path"] = self.model_name_or_path
 
-        return transformers.AutoProcessor.from_pretrained(
-            model_name_or_path,
-            **self.processor_kwargs,
-        )
+        return transformers.AutoProcessor.from_pretrained(**self.processor_kwargs)
 
     def _unpack_batch(self, batch: TextImageBatch | TextBatch) -> tuple:
         if isinstance(batch, TextImageBatch):


### PR DESCRIPTION
E.g. for fine tuned models where `self.model_name_or_path` is set to the checkpoint path, the processor we still might want to load from the original model source.