### PR TITLE
Make image input kwarg in multimodal processor configurable

### DIFF
--- a/src/eva/multimodal/models/networks/others.py
+++ b/src/eva/multimodal/models/networks/others.py
@@ -44,4 +44,5 @@ class PathoR13b(wrappers.HuggingFaceModel):
                 "max_pixels": 451584,  # 672*672
             },
             system_prompt=system_prompt,
+            image_key="images",
         )

--- a/src/eva/multimodal/models/wrappers/huggingface.py
+++ b/src/eva/multimodal/models/wrappers/huggingface.py
@@ -35,6 +35,7 @@ class HuggingFaceModel(base.VisionLanguageModel):
         system_prompt: str | None = None,
         processor_kwargs: Dict[str, Any] | None = None,
         generation_kwargs: Dict[str, Any] | None = None,
+        image_alias: str = "image",
     ):
         """Initialize the HuggingFace model wrapper.
 
@@ -45,6 +46,7 @@ class HuggingFaceModel(base.VisionLanguageModel):
             system_prompt: System prompt to use.
             processor_kwargs: Additional processor arguments.
             generation_kwargs: Additional generation arguments.
+            image_alias: The alias used for image inputs in the chat template.
         """
         super().__init__(system_prompt=system_prompt)
 
@@ -53,6 +55,7 @@ class HuggingFaceModel(base.VisionLanguageModel):
         self.base_model_class = model_class
         self.processor_kwargs = processor_kwargs or {}
         self.generation_kwargs = generation_kwargs or {}
+        self.image_alias = image_alias
 
         self.processor = self.load_processor()
         self.model = self.load_model()
@@ -105,7 +108,7 @@ class HuggingFaceModel(base.VisionLanguageModel):
         }
 
         if with_images:
-            processor_inputs["image"] = [[image] for image in image_batch]
+            processor_inputs[self.image_alias] = [[image] for image in image_batch]
 
         return self.processor(**processor_inputs).to(self.model.device)  # type: ignore
 

--- a/src/eva/multimodal/models/wrappers/huggingface.py
+++ b/src/eva/multimodal/models/wrappers/huggingface.py
@@ -35,7 +35,7 @@ class HuggingFaceModel(base.VisionLanguageModel):
         system_prompt: str | None = None,
         processor_kwargs: Dict[str, Any] | None = None,
         generation_kwargs: Dict[str, Any] | None = None,
-        image_alias: str = "image",
+        image_key: str = "image",
     ):
         """Initialize the HuggingFace model wrapper.
 
@@ -46,7 +46,7 @@ class HuggingFaceModel(base.VisionLanguageModel):
             system_prompt: System prompt to use.
             processor_kwargs: Additional processor arguments.
             generation_kwargs: Additional generation arguments.
-            image_alias: The alias used for image inputs in the chat template.
+            image_key: The key used for image inputs in the chat template.
         """
         super().__init__(system_prompt=system_prompt)
 
@@ -55,7 +55,7 @@ class HuggingFaceModel(base.VisionLanguageModel):
         self.base_model_class = model_class
         self.processor_kwargs = processor_kwargs or {}
         self.generation_kwargs = generation_kwargs or {}
-        self.image_alias = image_alias
+        self.image_key = image_key
 
         self.processor = self.load_processor()
         self.model = self.load_model()
@@ -108,7 +108,7 @@ class HuggingFaceModel(base.VisionLanguageModel):
         }
 
         if with_images:
-            processor_inputs[self.image_alias] = [[image] for image in image_batch]
+            processor_inputs[self.image_key] = [[image] for image in image_batch]
 
         return self.processor(**processor_inputs).to(self.model.device)  # type: ignore
 


### PR DESCRIPTION
PR to make the `image` keyword for multimodal processors configurable, which can differ between models (most commonly `image`, e.g., Qwen-2.5VL, and `images`, e.g., Patho-R1, MedGemma)