### PR TITLE
Add support for equals-separated cli args to `ConfigurationLogger`

### DIFF
--- a/src/eva/core/callbacks/config.py
+++ b/src/eva/core/callbacks/config.py
@@ -135,7 +135,8 @@ def _fetch_submitted_config_path() -> List[str]:
     Returns:
         The path to the configuration file.
     """
-    return list(filter(lambda f: f.endswith(".yaml"), sys.argv))
+    config_paths = list(filter(lambda f: f.endswith(".yaml"), sys.argv))
+    return [p.replace("--config=", "") for p in config_paths]
 
 
 def _load_yaml_files(paths: List[str], cli_overrides: List[str] | None = None) -> Dict[str, Any]:


### PR DESCRIPTION
Follow up to https://github.com/kaiko-ai/eva/issues/917

Without this fix, the `ConfigurationLogger` doens't correctly parse CLI args that use `=` as separator.

`eva fit --config configs/vision/pathology/online/classification/mhist.yaml --trainer.init_args.n_runs=6`