### PR TITLE
ci: add zizmor for GH workflow SAST

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -6,15 +6,21 @@ on:
     branches:
       - main
 
-permissions:
-  id-token: write
-  contents: write
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
-  release-pypi:
+  deploy-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed for pushing to GitHub Pages
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        with:
+          persist-credentials: false
       - name: Setting up PDM
         uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,13 +4,22 @@ name: CI
 on:
   pull_request:
     branches:
+      - "**"
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Setting up PDM
         uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4
         with:
@@ -28,9 +37,9 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-latest
+          - ubuntu-latest
         python-version:
-        - "3.10"
+          - "3.10"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install OS dependencies
@@ -40,9 +49,10 @@ jobs:
           sudo add-apt-repository ppa:openslide/openslide
           sudo apt install -y openslide-tools
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           lfs: true
+          persist-credentials: false
       - name: Setting up PDM
         uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4
         with:
@@ -58,7 +68,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Setting up PDM
         uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4
         with:
@@ -76,9 +88,13 @@ jobs:
         run: nox -s docs -- deploy --update-aliases dev
   security:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Needed for uploading SARIF reports
     steps:
       - name: Checkout
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Perform gitleaks checks
         run: |
           # Download and check
@@ -93,3 +109,9 @@ jobs:
             --config .gitleaks.toml \
             --gitleaks-ignore-path .gitleaksignore \
             --no-git
+      - name: Perform GitHub actions and workflows SAST
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0
+        with:
+          min-severity: low
+          persona: pedantic
+          version: latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,20 +6,23 @@ on:
     tags:
       - "*"
 
-permissions:
-  id-token: write
-  contents: write
-  pull-requests: write
+concurrency:
+  group: "${{ github.workflow }}"
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   release-pypi:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: write
-      pull-requests: write
+      id-token: write # Needed for publishing to PyPI
+      contents: write # Needed for pushing to GitHub Pages
+      pull-requests: write # Needed for creating version bump PR
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
       - name: Setting up PDM
         uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4
         with:
@@ -35,7 +38,7 @@ jobs:
           git config user.name "GitHub Action"
       - name: Bumping version
         run: |
-          nox -s bump -- to "${{ github.ref_name }}"
+          nox -s bump -- to "${GITHUB_REF_NAME}"
       - name: Build artifacts
         run: |
           nox -s build
@@ -46,7 +49,7 @@ jobs:
       - name: Build Release Docs
         run: |
           git fetch origin gh-pages:gh-pages
-          tag="${{ github.ref_name }}"
+          tag="${GITHUB_REF_NAME}"
           DOC_VERSION=${tag%.*}
           nox -s docs -- deploy --alias-type=copy --update-aliases "$DOC_VERSION"
           git push origin gh-pages
@@ -63,9 +66,9 @@ jobs:
           title: "bump version to ${{ github.ref_name }} [skip ci]"
           body: |
             This PR updates the pyproject.toml with the new version number.
-            
+
             Version: ${{ github.ref_name }}
-            
+
             *Automated PR created by the Release workflow*
           branch: bump-version-${{ github.ref_name }}
           base: main


### PR DESCRIPTION
Setup `zizmor` for scanning GitHub workflows for security problems.

Everything should be a no-op, except for removing `id-token: write` permission from the CD workflow (I don't think it's needed).