### PR TITLE
ci: re-add id-token permission to CD workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Needed for pushing to GitHub Pages
+      id-token: write # Needed for publishing to GitHub Pages
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:


### PR DESCRIPTION
After removing `id-token` permission from the CD workflow in #927, the workflow is failing.

Seems like that permission is needed to attest the origin of the workflow; https://github.com/actions/deploy-pages/issues/329#issuecomment-2030446649.