### PR TITLE
ci: persist git credentials for pushing in CD

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           # Needed to push to gh-pages branch
-          # IMPORTANT: Make sure to ONLY PUSH TO gh-pages branch to avoid leaking credentials
+          # IMPORTANT: Avoid publishing the .git/ folder to prevent leaking credentials
           persist-credentials: true
       - name: Setting up PDM
         uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          persist-credentials: false
+          # Needed to push to gh-pages branch
+          # IMPORTANT: Avoid publishing the .git/ folder to prevent leaking credentials
+          persist-credentials: true
       - name: Setting up PDM
         uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4
         with:


### PR DESCRIPTION
Solves the issue where the CD workflow does not have the credentials to push to the `gh-pages` branch.

> [!important]
>
> `persist-credentials: true` stores the credentials used by `git`. This is fine for the purposes of doing `git` operations in following steps, but actions like `actions/upload-artifact` **must be avoided** since they may leak those credentials. The credentials are short-lived, but are not invalidated immediately after the workflow ends.
>
> More details: https://docs.zizmor.sh/audits/#artipacked