### PR TITLE
Fix wrong download instructions in tutorials

### DIFF
--- a/docs/user-guide/advanced/replicate_evaluations.md
+++ b/docs/user-guide/advanced/replicate_evaluations.md
@@ -7,7 +7,7 @@ You will need to download the config files and then in the following commands re
 
 Keep in mind:
 
-- Some datasets provide automatic download by setting the argument `download: true` (either modify the `.yaml` config file or set the environment variable `DOWNLOAD=true`), while other datasets need to be downloaded manually beforehand. Please review the instructions in the corresponding dataset [documentation](../../datasets/index.md).
+- Some datasets provide automatic download by setting the argument `download: true` (either modify the `.yaml` config file or set the environment variable `DOWNLOAD_DATA=true`), while other datasets need to be downloaded manually beforehand. Please review the instructions in the corresponding dataset [documentation](../../datasets/index.md).
 - The following `eva predict_fit` commands will store the generated embeddings to the `./data/embeddings` directory. To change this location you can alternatively set the `EMBEDDINGS_ROOT` environment variable.
 - Segmentation tasks need to be run in `online` mode because the decoder currently doesn't support evaluation with precomputed embeddings. In other words, use `fit --config .../online/<task>.yaml` instead of `predict_fit  --config .../offline/<task>.yam` here.
 

--- a/docs/user-guide/tutorials/offline_vs_online.md
+++ b/docs/user-guide/tutorials/offline_vs_online.md
@@ -7,7 +7,7 @@ If you haven't downloaded the config files yet, please download them from [GitHu
 
 For this tutorial we use the [BACH](../../datasets/bach.md) classification task which is available on [Zenodo](https://zenodo.org/records/3632035) and is distributed under [*Attribution-NonCommercial-ShareAlike 4.0 International*](https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode) license.
 
-To let *eva* automatically handle the dataset download, set `download: true` in `configs/vision/pathology/offline/classification/bach.yaml` (you may also enable automatic download by setting the environment variable `DOWNLOAD=true`). Additionally, you can set `DATA_ROOT` to configure the location of where the dataset will be downloaded to / loaded from during evaluation (the default is `./data` which will be used in the following examples).
+To let *eva* automatically handle the dataset download, set `download: true` in `configs/vision/pathology/offline/classification/bach.yaml` (you may also enable automatic download by setting the environment variable `DOWNLOAD_DATA=true`). Additionally, you can set `DATA_ROOT` to configure the location of where the dataset will be downloaded to / loaded from during evaluation (the default is `./data` which will be used in the following examples).
 
 Before doing so, please make sure that your use case is compliant with the dataset license. Note that not all datasets support automatic download.
 


### PR DESCRIPTION
Tutorials mentioned a `DOWNLOAD` env variable, but the yaml configs use `DOWNLOAD_DATA`.