### PR TITLE
Implement abstract function in prompt template factories

### DIFF
--- a/src/eva/language/prompts/templates/factory.py
+++ b/src/eva/language/prompts/templates/factory.py
@@ -2,6 +2,8 @@
 
 from typing import Literal
 
+from typing_extensions import override
+
 from eva.language.prompts.templates.base import PromptTemplate
 from eva.language.prompts.templates.json import (
     JsonFreeFormQuestionPromptTemplate,
@@ -42,6 +44,10 @@ class FreeFormQuestionPromptTemplate(PromptTemplate):
             case _:
                 raise ValueError(f"Unknown answer format: {answer_format}")
 
+    @override
+    def render(self, **kwargs) -> str:
+        raise NotImplementedError("Factory class should not be instantiated directly.")
+
 
 class MultipleChoicePromptTemplate(PromptTemplate):
     """Factory for Multiple Choice QA prompt templates based on answer format."""
@@ -67,3 +73,7 @@ class MultipleChoicePromptTemplate(PromptTemplate):
                 return RawMultipleChoicePromptTemplate(**template_kwargs)
             case _:
                 raise ValueError(f"Unknown answer format: {answer_format}")
+
+    @override
+    def render(self, **kwargs) -> str:
+        raise NotImplementedError("Factory class should not be instantiated directly.")


### PR DESCRIPTION
The factory classes subclass from the abstract class `PromptTemplate`, therefore need to implement the abstract methods.

Without this you get these linting issues:

<img width="577" height="290" alt="image" src="https://github.com/user-attachments/assets/fe9bf33e-7fcb-48e9-a529-e1516eb089ea" />
