### PR TITLE
Add `configure_model` method

### DIFF
--- a/src/eva/multimodal/models/modules/vision_language.py
+++ b/src/eva/multimodal/models/modules/vision_language.py
@@ -5,14 +5,13 @@ from typing import Any
 from lightning.pytorch.utilities.types import STEP_OUTPUT
 from torch import nn
 from typing_extensions import override
-from loguru import logger
 
 from eva.core.metrics import structs as metrics_lib
 from eva.core.models.modules import module
 from eva.core.models.modules.utils import batch_postprocess
 from eva.language.models.typings import ModelOutput
-from eva.multimodal.models.typings import TextImageBatch
 from eva.multimodal.models import wrappers
+from eva.multimodal.models.typings import TextImageBatch
 
 
 class VisionLanguageModule(module.ModelModule):
@@ -59,6 +58,8 @@ class VisionLanguageModule(module.ModelModule):
 
     @override
     def configure_model(self) -> None:
-        model = self.model.model if isinstance(self.model, wrappers.ModelFromRegistry) else self.model
+        model = (
+            self.model.model if isinstance(self.model, wrappers.ModelFromRegistry) else self.model
+        )
         if hasattr(model, "configure_model"):
             model.configure_model()  # type: ignore

--- a/src/eva/multimodal/models/wrappers/huggingface.py
+++ b/src/eva/multimodal/models/wrappers/huggingface.py
@@ -47,7 +47,7 @@ class HuggingFaceModel(base.VisionLanguageModel):
         generation_kwargs: Dict[str, Any] | None = None,
         image_key: str = "image",
         image_position: Literal["before_text", "after_text"] = "after_text",
-        initialize_model: bool = False, # TODO: default to True?
+        initialize_model: bool = True,
     ):
         """Initialize the HuggingFace model wrapper.
 
@@ -176,7 +176,6 @@ class HuggingFaceModel(base.VisionLanguageModel):
         if not hasattr(model, "generate"):
             raise ValueError(f"Model {self.model_name_or_path} does not support generation. ")
 
-        model.eval()
         self.is_loaded = True
 
         return model


### PR DESCRIPTION
For loading large models with distributed strategies, lightning recommends loading the model weights within the `configure_model` hook:
https://lightning.ai/docs/pytorch/stable/advanced/model_parallel/fsdp.html#speed-up-model-initialization