### PR TITLE
Render role correctly in string format

### DIFF
--- a/src/eva/language/data/messages.py
+++ b/src/eva/language/data/messages.py
@@ -12,6 +12,10 @@ class Role(str, enum.Enum):
     ASSISTANT = "assistant"
     SYSTEM = "system"
 
+    def __str__(self) -> str:
+        """String representation of the Role enum."""
+        return self.value
+
 
 @dataclasses.dataclass
 class Message:


### PR DESCRIPTION
Fixes a bug in which the roles were incorrectly rendered as `Role.USER` instead of `user` when processed in a string format (`str()`, `print()`, `f""`, ...). This can impact actual model performance if the messages are explicitly cast to string before templating (which apparently happens in the Qwen-VL processor), and also cause confusion when logging the input conversation, which happens in the `HuggingFaceModel` in `eva` ([here](https://github.com/kaiko-ai/eva/blob/de99b50484ef0f6d411160d86617c731dcd888e7/src/eva/multimodal/models/wrappers/huggingface.py#L195C1-L196C1)).

Credits to @nkaenzig for the change