### PR TITLE
Update `vLLM` default params to improve stability

### DIFF
--- a/src/eva/language/models/modules/language.py
+++ b/src/eva/language/models/modules/language.py
@@ -34,9 +34,7 @@ class LanguageModule(module.ModelModule):
 
     @override
     def configure_model(self) -> None:
-        from eva.language.models.wrappers.from_registry import ModelFromRegistry
-
-        model = self.model.model if isinstance(self.model, ModelFromRegistry) else self.model
+        model = self.model.model if hasattr(self.model, "model") else self.model
         if hasattr(model, "configure_model"):
             model.configure_model()  # type: ignore
 

--- a/src/eva/multimodal/models/networks/alibaba.py
+++ b/src/eva/multimodal/models/networks/alibaba.py
@@ -75,6 +75,7 @@ if import_utils.is_vllm_available():
                 model_name_or_path="Qwen/Qwen2.5-VL-72B-Instruct",
                 model_kwargs={
                     "tensor_parallel_size": int(os.getenv("VLLM_TENSOR_PARALLEL_SIZE", 4)),
+                    "max_num_seqs": 16,
                 },
                 image_position="before_text",
                 system_prompt=system_prompt,

--- a/src/eva/multimodal/models/wrappers/vllm.py
+++ b/src/eva/multimodal/models/wrappers/vllm.py
@@ -39,9 +39,10 @@ class VllmModel(base.VisionLanguageModel):
 
     _default_model_kwargs = {
         "max_model_len": 32768,
-        "gpu_memory_utilization": 0.95,
+        "gpu_memory_utilization": 0.9,
         "tensor_parallel_size": 1,
         "trust_remote_code": True,
+        "enforce_eager": True,  #  reduce start-up time & potential compilation issues
     }
 
     _default_generation_kwargs = {


### PR DESCRIPTION
- reduce `max_num_seqs` for 72b qwen model (to reduce batch sizes / number of concurrent requests in a batch and therefore lower risk of OOM issues)
- `enforce_eager=True` disables torch model compilation, speeding up initial start time & avoiding potential compilation issues
- reduce `gpu_memory_utilization` from `0.9` to be more conservative / safer when memory peaks happen