### PR TITLE
Fix unpack model logic for `ModelFromRegistry` models

### DIFF
--- a/src/eva/language/models/modules/language.py
+++ b/src/eva/language/models/modules/language.py
@@ -34,7 +34,7 @@ class LanguageModule(module.ModelModule):
 
     @override
     def configure_model(self) -> None:
-        model = self.model.model if hasattr(self.model, "model") else self.model
+        model = self.model.model if type(self.model).__name__ == "ModelFromRegistry" else self.model
         if hasattr(model, "configure_model"):
             model.configure_model()  # type: ignore
 

--- a/src/eva/language/models/wrappers/from_registry.py
+++ b/src/eva/language/models/wrappers/from_registry.py
@@ -45,8 +45,6 @@ class ModelFromRegistry(base.BaseModel[TextBatch, List[str]]):
 
     @override
     def load_model(self) -> nn.Module:
-        ModelFromRegistry.__name__ = self._model_name
-
         return factory.ModuleFactory(
             registry=model_registry,
             name=self._model_name,

--- a/src/eva/multimodal/models/modules/vision_language.py
+++ b/src/eva/multimodal/models/modules/vision_language.py
@@ -10,7 +10,6 @@ from eva.core.metrics import structs as metrics_lib
 from eva.core.models.modules import module
 from eva.core.models.modules.utils import batch_postprocess
 from eva.language.models.typings import ModelOutput
-from eva.multimodal.models import wrappers
 from eva.multimodal.models.typings import TextImageBatch
 
 
@@ -36,9 +35,7 @@ class VisionLanguageModule(module.ModelModule):
 
     @override
     def configure_model(self) -> None:
-        model = (
-            self.model.model if isinstance(self.model, wrappers.ModelFromRegistry) else self.model
-        )
+        model = self.model.model if type(self.model).__name__ == "ModelFromRegistry" else self.model
         if hasattr(model, "configure_model"):
             model.configure_model()  # type: ignore
 

--- a/src/eva/multimodal/models/wrappers/from_registry.py
+++ b/src/eva/multimodal/models/wrappers/from_registry.py
@@ -45,8 +45,6 @@ class ModelFromRegistry(base.BaseModel[TextImageBatch, List[str]]):
 
     @override
     def load_model(self) -> nn.Module:
-        ModelFromRegistry.__name__ = self._model_name
-
         return factory.ModuleFactory(
             registry=model_registry,
             name=self._model_name,

--- a/src/eva/vision/models/wrappers/from_registry.py
+++ b/src/eva/vision/models/wrappers/from_registry.py
@@ -45,8 +45,6 @@ class ModelFromRegistry(base.BaseModel[torch.Tensor, torch.Tensor]):
 
     @override
     def load_model(self) -> nn.Module:
-        ModelFromRegistry.__name__ = self._model_name
-
         return factory.ModuleFactory(
             registry=backbone_registry,
             name=self._model_name,


### PR DESCRIPTION
This unpack operation should only be done when the model is a `ModelFromRegistry` instance, because in that case the real model is stored within the `.model` attribute. However, the previous logic would break when loading a model not through the registry, and which also happens to have a `.model` attribute.