### PR TITLE
Reinstate int conversion of `missing_answer` in discrete extraction

### DIFF
--- a/src/eva/language/models/postprocess/extract_answer/base.py
+++ b/src/eva/language/models/postprocess/extract_answer/base.py
@@ -135,7 +135,7 @@ class ExtractDiscreteAnswerFromStructuredOutput(ExtractAnswerFromStructuredOutpu
             return_dict=False,
         )
 
-        self.missing_discrete_answer = missing_answer
+        self.missing_discrete_answer = int(missing_answer)
         self.mapping = {k if case_sensitive else k.lower(): v for k, v in mapping.items()}
 
     @override


### PR DESCRIPTION
Fixes a bug where the `missing_answer` was not explicitly cast to `int` in the discrete extraction class - when defining the missing answer in YAML configs, the value is treated as string and leads to downstream errors as strings are not expected.