### PR TITLE
Expose `compute_groups` and `separator` via `MetricsSchema`

### DIFF
--- a/src/eva/core/metrics/structs/module.py
+++ b/src/eva/core/metrics/structs/module.py
@@ -48,7 +48,7 @@ class MetricModule(nn.Module):
         test: MetricModuleType | None,
         *,
         separator: str = "/",
-        compute_groups: bool | List[List[str]] = True,
+        compute_groups: bool = True,
     ) -> MetricModule:
         """Initializes a metric module from a list of metrics.
 
@@ -75,25 +75,18 @@ class MetricModule(nn.Module):
         )
 
     @classmethod
-    def from_schema(
-        cls, schema: schemas.MetricsSchema, *, separator: str = "/", compute_groups: bool = True
-    ) -> MetricModule:
+    def from_schema(cls, schema: schemas.MetricsSchema) -> MetricModule:
         """Initializes a metric module from the metrics schema.
 
         Args:
             schema: The dataclass metric schema.
-            separator: The separator between the group name of the metric
-                and the metric itself.
-            compute_groups: All metrics in a compute group share the same metric state
-                and are therefore only different in their compute step. To disable this
-                behavior, set to `False`.
         """
         return cls.from_metrics(
             train=schema.training_metrics,
             val=schema.evaluation_metrics,
             test=schema.evaluation_metrics,
-            separator=separator,
-            compute_groups=compute_groups,
+            separator=schema.separator,
+            compute_groups=schema.compute_groups,
         )
 
     @property

--- a/src/eva/core/metrics/structs/schemas.py
+++ b/src/eva/core/metrics/structs/schemas.py
@@ -18,6 +18,12 @@ class MetricsSchema:
     evaluation: MetricModuleType | None = None
     """The exclusive evaluation metrics."""
 
+    compute_groups: bool = True
+    """Whether to share the same states across metrics in a collection."""
+
+    separator: str = "/"
+    """The separator between the group name of the metric and the metric itself."""
+
     @property
     def training_metrics(self) -> MetricModuleType | None:
         """Returns the training metics."""

--- a/tests/eva/core/metrics/core/test_metric_module.py
+++ b/tests/eva/core/metrics/core/test_metric_module.py
@@ -35,3 +35,30 @@ def test_metric_module(metric_module: structs.MetricModule, expected: List[int])
 def metric_module(schema: structs.MetricsSchema) -> structs.MetricModule:
     """MetricModule fixture."""
     return structs.MetricModule.from_schema(schema=schema)
+
+
+@pytest.mark.parametrize(
+    "compute_groups, separator",
+    [
+        (True, "/"),
+        (False, "/"),
+        (True, "_"),
+        (False, "-"),
+    ],
+)
+def test_metric_module_schema_options(compute_groups: bool, separator: str) -> None:
+    """Tests that compute_groups and separator are correctly passed from schema."""
+    schema = structs.MetricsSchema(
+        common=torchmetrics.Accuracy(task="binary"),
+        compute_groups=compute_groups,
+        separator=separator,
+    )
+    metric_module = structs.MetricModule.from_schema(schema=schema)
+
+    # Check that separator is applied in metric prefixes
+    for name in metric_module.training_metrics.keys():
+        assert str(name).startswith(f"train{separator}")
+    for name in metric_module.validation_metrics.keys():
+        assert str(name).startswith(f"val{separator}")
+    for name in metric_module.test_metrics.keys():
+        assert str(name).startswith(f"test{separator}")


### PR DESCRIPTION
Closes #981

This now enables, setting `compute_groups` and `separator` via .yaml config files to override the defaults:

```yaml
    metrics:
      common:
        - class_path: eva.metrics.AverageLoss
        - class_path: eva.metrics.BinaryClassificationMetrics
      compute_groups: false
      separator: "/"
```