### PR TITLE
fix: filter predictions with ignore_index in MulticlassClassificationMetrics

### DIFF
--- a/src/eva/core/metrics/defaults/classification/multiclass.py
+++ b/src/eva/core/metrics/defaults/classification/multiclass.py
@@ -2,6 +2,7 @@
 
 from typing import Literal
 
+import torch
 from torchmetrics import classification
 
 from eva.core.metrics import structs
@@ -80,3 +81,23 @@ class MulticlassClassificationMetrics(structs.MetricCollection):
             postfix=postfix,
             compute_groups=compute_groups,
         )
+        # Set after torchmetrics init to avoid potential state reset side-effects.
+        self._ignore_index = ignore_index
+
+    def update(self, preds: torch.Tensor, target: torch.Tensor) -> None:
+        """Updates metrics, filtering out predictions matching ignore_index.
+
+        torchmetrics' ignore_index only filters targets, not predictions.
+        This causes torch.bincount to crash on negative prediction values
+        (e.g. -1 from missing_answer). We filter both here.
+
+        Args:
+            preds: Model predictions.
+            target: Ground truth labels.
+        """
+        if self._ignore_index is not None:
+            valid_mask = preds != self._ignore_index
+            if not valid_mask.any():
+                return
+            preds, target = preds[valid_mask], target[valid_mask]
+        super().update(preds, target)

--- a/tests/eva/core/metrics/defaults/classification/test_multiclass.py
+++ b/tests/eva/core/metrics/defaults/classification/test_multiclass.py
@@ -49,6 +49,35 @@ def test_multiclass_classification_metrics(
     _calculate_metric()
 
 
+def test_multiclass_metrics_filters_ignored_predictions() -> None:
+    """Tests that predictions matching ignore_index are filtered before metric update."""
+    metrics = defaults.MulticlassClassificationMetrics(
+        num_classes=3, input_type="discrete", ignore_index=-1
+    )
+    # Without filtering, -1 would cause: RuntimeError: bincount only supports
+    # 1-d non-negative integral inputs.
+    preds = torch.tensor([0, 1, -1, 2])
+    target = torch.tensor([0, 1, 2, 2])
+    metrics.update(preds=preds, target=target)
+    result = metrics.compute()
+    # Only the 3 valid samples are evaluated: preds=[0,1,2], target=[0,1,2] -> perfect
+    assert result["MulticlassAccuracy"] == 1.0
+
+
+def test_multiclass_metrics_skips_all_ignored_predictions() -> None:
+    """Tests that an all-ignored batch doesn't crash and is effectively skipped."""
+    metrics = defaults.MulticlassClassificationMetrics(
+        num_classes=3, input_type="discrete", ignore_index=-1
+    )
+    # First batch: all ignored — should be skipped entirely
+    metrics.update(preds=torch.tensor([-1, -1]), target=torch.tensor([0, 1]))
+    # Second batch: valid data
+    metrics.update(preds=torch.tensor([0, 2]), target=torch.tensor([0, 2]))
+    result = metrics.compute()
+    # Only second batch counts
+    assert result["MulticlassAccuracy"] == 1.0
+
+
 @pytest.fixture(scope="function")
 def multiclass_classification_metrics(num_classes: int) -> defaults.MulticlassClassificationMetrics:
     """MulticlassClassificationMetrics fixture."""


### PR DESCRIPTION
## Summary
- torchmetrics' `ignore_index` only filters **targets**, not **predictions**. When a model produces unmappable answers (e.g. `"n/a"`), the answer extraction maps them to `-1`, which causes `torch.bincount` to crash on negative values.
- Overrides `update()` in `MulticlassClassificationMetrics` to filter out predictions matching `ignore_index` before they reach the underlying torchmetrics computation.
- Adds two tests: mixed valid/ignored predictions, and all-ignored batch followed by valid batch.

## Context
Discovered during CFMPB breast tubule formation benchmark evaluation — `alibaba/qwen2-5-vl-7b-instruct-vllm` returned `"n/a"` for some samples, which was mapped to `-1` by `ExtractDiscreteAnswer`, crashing `MulticlassAccuracy`/`MulticlassF1Score`.

## Test plan
- [x] Existing test still passes (`test_multiclass_classification_metrics`)
- [x] New test: predictions with ignore_index are filtered correctly
- [x] New test: all-ignored batch is skipped without crashing
- [x] Verified fix works on actual CFMPB benchmark run